### PR TITLE
Correct bazel version parsing in build.rs

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -47,7 +47,7 @@ fn main() {
         log!("{:?} already exists, not building", library_path);
     } else {
         if let Err(e) = check_bazel() {
-            println!("cargo:error=Bazel must be installed at be version {} or greater. (Error: {})", MIN_BAZEL, e);
+            println!("cargo:error=Bazel must be installed at version {} or greater. (Error: {})", MIN_BAZEL, e);
             process::exit(1);
         }
         let target_path = &TARGET.replace(":", "/");
@@ -110,7 +110,12 @@ fn check_bazel() -> Result<(), Box<Error>> {
     for line in stdout.lines() {
         if line.starts_with("Build label:") {
             found_version = true;
-            let version_str = line.split(":").nth(1).unwrap().trim();
+            let mut version_str = line.split(":").nth(1).unwrap()
+                .split(" ").nth(1).unwrap().trim();
+            if version_str.ends_with('-') {
+                // hyphen is 1 byte long, so it's safe
+                version_str = &version_str[..version_str.len() - 1];
+            }
             let version = try!(Version::parse(version_str));
             let want = try!(Version::parse(MIN_BAZEL));
             if version < want {


### PR DESCRIPTION
`tensorflow-sys` was failing to build in my system because apparently Bazel can report something like below, which was not being properly parsed by the building script.

```
Build label: 0.4.3- (@non-git)
Build target: bazel-out/local-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Mon Jan 23 11:31:26 2017 (1485171086)
Build timestamp: 1485171086
Build timestamp as int: 1485171086
```

This PR will make version checking resistant to additional non-whitespace text after the version, as well as a sole trailing hyphen (which is not compliant to semver and would also output a parsing error). I also took the liberty of fixing a typo in the related error message.