### PR TITLE
Fix build script and optimize native libtensorflow.

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use std::{env, fs};
 use semver::Version;
 
-const LIBRARY: &'static str = "tensorflow_c";
+const LIBRARY: &'static str = "tensorflow";
 const REPOSITORY: &'static str = "https://github.com/tensorflow/tensorflow.git";
 const TARGET: &'static str = "tensorflow:libtensorflow.so";
 const TAG: &'static str = "v1.0.0";
@@ -79,6 +79,7 @@ fn main() {
                 .arg("build")
                 .arg(format!("--jobs={}", get!("NUM_JOBS")))
                 .arg("--compilation_mode=opt")
+                .arg("--copt=-march=native")
                 .arg(TARGET)
         });
         let target_bazel_bin = source.join("bazel-bin").join(target_path);


### PR DESCRIPTION
This changeset provides two changes to the sys build file:

 1) After 7e6ee652bac5d15b86fe521d779b9267dbecff4f (the _c) rename
    the test suite doesn't work anymore since the proper artifact
    is not linked now. This has been fixed by modifying the LIBRARY
    static to reflect the new .so file.
 2) Since the library is built to be used on this specific machine
    the --copt=-march=native flag is now passed when building TF
    to make use of all the native features possible.

@adamcrume the first change mentioned here actually makes the build work again.