### PR TITLE
Fix various rustc and clippy warnings.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -194,7 +194,7 @@ impl<T: TensorType> Deref for Buffer<T> {
 
 impl<T: TensorType> DerefMut for Buffer<T> {
     #[inline]
-    fn deref_mut<'a>(&'a mut self) -> &'a mut [T] {
+    fn deref_mut(&mut self) -> &mut [T] {
         self.as_mut()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides Rust bindings for the
-//! [TensorFlow](https://www.tensorflow.org) machine learning library.
+//! [`TensorFlow`](https://www.tensorflow.org) machine learning library.
 
 #![warn(missing_copy_implementations,
         missing_debug_implementations,
@@ -343,6 +343,7 @@ c_enum!("Type of a single tensor element.", TF_DataType, DataType {
   /// 16-bit floating point.
   value Half = 19,
 
+  /// TensorFlow Resource (name, container, device,...)
   value Resource = 20,
 });
 
@@ -936,7 +937,7 @@ impl<T: TensorType> Deref for Tensor<T> {
 
 impl<T: TensorType> DerefMut for Tensor<T> {
     #[inline]
-    fn deref_mut<'a>(&'a mut self) -> &'a mut [T] {
+    fn deref_mut(&mut self) -> &mut [T] {
         &mut self.data
     }
 }
@@ -1010,7 +1011,7 @@ trait OperationTrait {
 ////////////////////////
 
 /// Returns a string describing version information of the
-/// TensorFlow library. TensorFlow using semantic versioning.
+/// `TensorFlow` library. `TensorFlow` is using semantic versioning.
 pub fn version() -> std::result::Result<String, Utf8Error> {
     unsafe { CStr::from_ptr(tf::TF_Version()).to_str().map(|s| s.to_string()) }
 }
@@ -1028,9 +1029,9 @@ pub struct Shape(Option<Vec<Option<i64>>>);
 impl Shape {
     /// Returns the number of dimensions if known, or None if unknown.
     pub fn dims(&self) -> Option<usize> {
-        match self {
-            &Shape(None) => None,
-            &Shape(Some(ref v)) => Some(v.len()),
+        match *self {
+            Shape(None) => None,
+            Shape(Some(ref v)) => Some(v.len()),
         }
     }
 }
@@ -1053,9 +1054,9 @@ impl Index<usize> for Shape {
     type Output = Option<i64>;
 
     fn index(&self, index: usize) -> &Option<i64> {
-        match &self.0 {
-            &None => &UNKNOWN_DIMENSION,
-            &Some(ref v) => {
+        match self.0 {
+            None => &UNKNOWN_DIMENSION,
+            Some(ref v) => {
                 if index < v.len() {
                     &v[index]
                 } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,4 @@
-extern crate tensorflow_sys as tf;
-
+use tf;
 use libc::c_int;
 use std::marker;
 use std::ptr;
@@ -20,9 +19,6 @@ use super::TensorType;
 pub struct Session {
     inner: *mut tf::TF_Session,
 }
-
-#[deprecated(note = "Use Session instead.")]
-type SessionWithGraph = Session;
 
 impl Session {
     /// Creates a session.
@@ -236,7 +232,6 @@ impl<'l> Drop for StepWithGraph<'l> {
 
 #[cfg(test)]
 mod tests {
-    extern crate tensorflow_sys as tf;
     use super::*;
     use super::super::DataType;
     use super::super::Graph;


### PR DESCRIPTION
This changeset fixes various rustc and clippy warnings. Note
that it also gets rid of some type aliases which have been
private and are unused in the library (and since they are
private they can't be used from outside anyways).