### PR TITLE
WIP: Run tensorflow-sys' test under valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   # is downloaded and available (if required).
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
   # FIXME: Make sure this does not fail the CI when pre-built binaries are used.
-  - export TFSO=$(ls $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
+  - export TFSO=$(ls -d $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
   - ls -d $TFSO
   - find $TFSO
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,16 +57,17 @@ script:
   - cargo run --example regression
   - cargo run --features tensorflow_unstable --example expressions
   # Run the tests through valgrind
-  # Clean the stable artifacts
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo clean; fi
-  # Compile the tests using the 'nightly' feature, then run them through valgrind
-  # FIXME: Add suppressions to ignore "errors" in cargo.
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo test --no-run -vv -j 2 --features tensorflow_unstable --features=nightly; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo test -vv -j 2 --features tensorflow_unstable --features=nightly; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --example regression --features=nightly; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --example regression --features=nightly; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --example regression --features=nightly; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --example regression --features=nightly; fi
+  # FIXME: Add `nightly` feature to main crate (to enable `alloc_system` feature)
+  # # Clean the stable artifacts
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo clean; fi
+  # # Compile the tests using the 'nightly' feature, then run them through valgrind
+  # # FIXME: Add suppressions to ignore "errors" in cargo.
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo test --no-run -vv -j 2 --features tensorflow_unstable --features=nightly; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo test -vv -j 2 --features tensorflow_unstable --features=nightly; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --example regression --features=nightly; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --example regression --features=nightly; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --features tensorflow_unstable --example expressions --features=nightly; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --features tensorflow_unstable --example expressions --features=nightly; fi
   # Now build the doc
   - cargo doc -vv --features tensorflow_unstable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ dist: trusty # still in beta, but required for the prebuilt TF binaries
 
 cache:
   cargo: true
-  directories:
-    - $HOME/.cache/bazel
+  # FIXME: We don't need bazel for now
+  # directories:
+  #   - $HOME/.cache/bazel
 
 rust:
   - stable
@@ -15,7 +16,8 @@ rust:
 
 install:
   - export CC="gcc-4.9" CXX="g++-4.9"
-  - source travis-ci/install.sh
+  # FIXME: We don't need bazel for now
+  # - source travis-ci/install.sh
 
 script:
   - export RUST_BACKTRACE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ script:
   - cargo run --example regression
   - cargo run --features tensorflow_unstable --example expressions
   - cargo doc -vv --features tensorflow_unstable
+  # Compile the tests, but don't run them. This makes sure the prebuilt tensorflow.so
+  # is downloaded and available (if required).
+  - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ addons:
       - oracle-java8-installer
       - python-numpy
       - swig
+      - valgrind
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
   # FIXME: Make sure this does not fail the CI when pre-built binaries are used.
   - export TFSO=$(ls $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
+  - ls -d $TFSO
+  - find $TFSO
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ script:
   # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && $valgrind cargo test -vv -j 1 --features=nightly); fi
   - export TEST_LIB_LINK=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/lib-*)
   - export TEST_LIB_SYS=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/tensorflow_sys-*)
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_LINK ; fi
+  # FIXME: Disable for now since valgrind just loop like crazy. See https://travis-ci.org/tensorflow/rust/jobs/211495588#L759
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_LINK ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_SYS ; fi
   # Now build and test the main crate
   - cargo test -vv -j 2 --features tensorflow_unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
   # FIXME: Make sure this does not fail the CI when pre-built binaries are used.
   - export TFSO=$(ls $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
-  - echo "TFSO: ${TFSO}"
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,14 @@ script:
   # Compile the tests using the 'nightly' feature, but don't run them.
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && cargo test --no-run -vv -j 1 --features=nightly); fi
   # Run the tests using valgrind.
-  # FIXME: Add suppressions to ignore "errors" in cargo.
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && $valgrind cargo test -vv -j 1 --features=nightly); fi
+  # FIXME: Running valgrind on cargo will catch "errors" inside cargo, not the binary to test. One could use
+  #        valgrind's `--trace-children=yes` but valgrind would still fail on cargo. Maybe suppressions could be
+  #        used. Meanwhile, just call the binaries directly.
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && $valgrind cargo test -vv -j 1 --features=nightly); fi
+  - export TEST_LIB_LINK=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/lib-*)
+  - export TEST_LIB_SYS=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/tensorflow_sys-*)
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_LINK ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_SYS ; fi
   # Now build and test the main crate
   - cargo test -vv -j 2 --features tensorflow_unstable
   - cargo run --example regression

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   # Compile the tests, but don't run them. This makes sure the prebuilt tensorflow.so
   # is downloaded and available (if required).
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
+  - tree
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
   # Compile the tests, but don't run them. This makes sure the prebuilt tensorflow.so
   # is downloaded and available (if required).
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
-  - tree
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,17 @@ script:
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
+  # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)
+  # does not work with valgrind. One has to use the system allocator (`alloc_system`) which
+  # is only available on nightly.
+  # Clean the stable artifacts
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && cargo clean); fi
+  # Compile the tests using the 'nightly' feature, but don't run them.
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && cargo test --no-run -vv -j 1 --features=nightly); fi
+  # Run the tests using valgrind.
+  # FIXME: Add suppressions to ignore "errors" in cargo.
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && valgrind --error-exitcode=42 --leak-check=full cargo test -vv -j 1 --features=nightly); fi
+
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,17 @@ script:
   - cargo test -vv -j 2 --features tensorflow_unstable
   - cargo run --example regression
   - cargo run --features tensorflow_unstable --example expressions
+  # Run the tests through valgrind
+  # Clean the stable artifacts
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo clean; fi
+  # Compile the tests using the 'nightly' feature, then run them through valgrind
+  # FIXME: Add suppressions to ignore "errors" in cargo.
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo test --no-run -vv -j 2 --features tensorflow_unstable --features=nightly; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo test -vv -j 2 --features tensorflow_unstable --features=nightly; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --example regression --features=nightly; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --example regression --features=nightly; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then           cargo build --example regression --features=nightly; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind cargo run   --example regression --features=nightly; fi
   # Now build the doc
   - cargo doc -vv --features tensorflow_unstable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   # directories:
   #   - $HOME/.cache/bazel
 
+env:
+  - valgrind="valgrind --error-exitcode=42 --leak-check=full"
+
 rust:
   - stable
   # FIXME: Should nightly be allowed to fail? Should a specific nightly
@@ -40,7 +43,7 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && cargo test --no-run -vv -j 1 --features=nightly); fi
   # Run the tests using valgrind.
   # FIXME: Add suppressions to ignore "errors" in cargo.
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && valgrind --error-exitcode=42 --leak-check=full cargo test -vv -j 1 --features=nightly); fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && $valgrind cargo test -vv -j 1 --features=nightly); fi
 
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ script:
   # Compile the tests, but don't run them. This makes sure the prebuilt tensorflow.so
   # is downloaded and available (if required).
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
+  # FIXME: Make sure this does not fail the CI when pre-built binaries are used.
+  - export TFSO=$(ls $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
+  - echo "TFSO: ${TFSO}"
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
   - export TFSO=$(ls -d $TRAVIS_BUILD_DIR/tensorflow-sys/target/libtensorflow-*-*-*-*/lib/)
   - ls -d $TFSO
   - find $TFSO
+  - export LD_LIBRARY_PATH=$TFSO
   - # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
   - (cd tensorflow-sys && cargo doc -vv)
   # Run tests through valgrind, but only on nightly since Rust's standard allocator (jemalloc)
@@ -49,8 +50,8 @@ script:
   - export TEST_LIB_LINK=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/lib-*)
   - export TEST_LIB_SYS=$(ls $TRAVIS_BUILD_DIR/target/debug/deps/tensorflow_sys-*)
   # FIXME: Disable for now since valgrind just loop like crazy. See https://travis-ci.org/tensorflow/rust/jobs/211495588#L759
-  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_LINK ; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then LD_LIBRARY_PATH=$TFSO $valgrind $TEST_LIB_SYS ; fi
+  # - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind $TEST_LIB_LINK ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then $valgrind $TEST_LIB_SYS ; fi
   # Now build and test the main crate
   - cargo test -vv -j 2 --features tensorflow_unstable
   - cargo run --example regression

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ cache:
   directories:
     - $HOME/.cache/bazel
 
-rust: stable
+rust:
+  - stable
+  # FIXME: Should nightly be allowed to fail? Should a specific nightly
+  #        be pinned and _not_ allowed to fail?
+  - nightly
 
 install:
   - export CC="gcc-4.9" CXX="g++-4.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ install:
 
 script:
   - export RUST_BACKTRACE=1
-  - cargo test -vv -j 2 --features tensorflow_unstable
-  - cargo run --example regression
-  - cargo run --features tensorflow_unstable --example expressions
-  - cargo doc -vv --features tensorflow_unstable
+  # Build and test the tensorflow-sys crate first
   # Compile the tests, but don't run them. This makes sure the prebuilt tensorflow.so
   # is downloaded and available (if required).
   - (cd tensorflow-sys && cargo test --no-run -vv -j 1)
@@ -44,6 +41,12 @@ script:
   # Run the tests using valgrind.
   # FIXME: Add suppressions to ignore "errors" in cargo.
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cd tensorflow-sys && $valgrind cargo test -vv -j 1 --features=nightly); fi
+  # Now build and test the main crate
+  - cargo test -vv -j 2 --features tensorflow_unstable
+  - cargo run --example regression
+  - cargo run --features tensorflow_unstable --example expressions
+  # Now build the doc
+  - cargo doc -vv --features tensorflow_unstable
 
 
 addons:

--- a/tensorflow-sys/Cargo.toml
+++ b/tensorflow-sys/Cargo.toml
@@ -25,3 +25,4 @@ tar = "0.4"
 
 [features]
 tensorflow_gpu = []
+nightly = []

--- a/tensorflow-sys/src/lib.rs
+++ b/tensorflow-sys/src/lib.rs
@@ -2,6 +2,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
+#![cfg_attr(feature="nightly", feature(alloc_system))]
+#[cfg(feature="nightly")]
+extern crate alloc_system;
+
 include!("bindgen.rs");
 
 pub use TF_Code::*;


### PR DESCRIPTION
This is a work-in-progress for running `tensorflow-sys`' tests under valgrind.

This PR is not yet ready: it's hard to debug without opening a pull request.

Should close #69.