### PR TITLE
Fix running under nightly: copy prebuilt `libtensorflow.so` to `OUT_DIR`

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -127,11 +127,11 @@ fn install_prebuilt() {
     let output = PathBuf::from(&get!("OUT_DIR"));
     let new_library_full_path = output.join(&library_file);
     if new_library_full_path.exists() {
-        println!("File {} already exists, deleting.", new_library_full_path.display());
+        log!("File {} already exists, deleting.", new_library_full_path.display());
         std::fs::remove_file(&new_library_full_path).unwrap();
     }
 
-    println!("Copying {} to {}...", library_full_path.display(), new_library_full_path.display());
+    log!("Copying {} to {}...", library_full_path.display(), new_library_full_path.display());
     std::fs::copy(&library_full_path, &new_library_full_path).unwrap();
     println!("cargo:rustc-link-search={}", output.display());
 }

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -112,7 +112,9 @@ fn install_prebuilt() {
     // Extract the tarball.
     let unpacked_dir = download_dir.join(base_name);
     let lib_dir = unpacked_dir.join("lib");
-    if !lib_dir.join(format!("lib{}.so", LIBRARY)).exists() {
+    let library_file = format!("lib{}.so", LIBRARY);
+    let library_full_path = lib_dir.join(&library_file);
+    if !library_full_path.exists() {
         extract(file_name, &unpacked_dir);
     }
 
@@ -122,7 +124,16 @@ fn install_prebuilt() {
         }); // TODO: remove
 
     println!("cargo:rustc-link-lib=dylib={}", LIBRARY);
-    println!("cargo:rustc-link-search={}", lib_dir.display());
+    let output = PathBuf::from(&get!("OUT_DIR"));
+    let new_library_full_path = output.join(&library_file);
+    if new_library_full_path.exists() {
+        println!("File {} already exists, deleting.", new_library_full_path.display());
+        std::fs::remove_file(&new_library_full_path).unwrap();
+    }
+
+    println!("Copying {} to {}...", library_full_path.display(), new_library_full_path.display());
+    std::fs::copy(&library_full_path, &new_library_full_path).unwrap();
+    println!("cargo:rustc-link-search={}", output.display());
 }
 
 fn build_from_src() {


### PR DESCRIPTION
A change in cargo nightly (merged on February 7th 2017) changed how
dynamic libraries are loaded. This prevented the `tensorflow-sys` crate's
tests to run.

To fix, simply copy the `libtensorflow.so` pre-built library to `OUT_DIR`
and change `cargo:rustc-link-search=` path so cargo can find it when
running the tests.

Note that I believe the library compiled from source does not seems to be
affected by the problem as it is already copied to `OUT_DIR`. This would
need to be verified though.

See:
* issue: https://github.com/tensorflow/rust/issues/71
* cargo's pull request: https://github.com/rust-lang/cargo/pull/3651