### PR TITLE
Increase Travis coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ env:
     - TF_RUST_BUILD_FROM_SRC=false
 
 
+matrix:
+  allow_failures:
+    - rust: nightly
+
+
 install:
   # Install dependencies only if we build tensorflow from source.
   - if [[ "$TF_RUST_BUILD_FROM_SRC" == "true" ]]; then source travis-ci/install.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,14 @@ env:
     - RUST_BACKTRACE=1
     - CC="gcc-4.9"
     - CXX="g++-4.9"
+  matrix:
+    - TF_RUST_BUILD_FROM_SRC=true
+    - TF_RUST_BUILD_FROM_SRC=false
+
 
 install:
-  - source travis-ci/install.sh
+  # Install dependencies only if we build tensorflow from source.
+  - if [[ "$TF_RUST_BUILD_FROM_SRC" == "true" ]]; then source travis-ci/install.sh; fi
 
 script:
   - cargo test -vv -j 2 --features tensorflow_unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 install:
   # Install dependencies only if we build tensorflow from source.
   - if [[ "$TF_RUST_BUILD_FROM_SRC" == "true" ]]; then source travis-ci/install.sh; fi
+  - if [[ "$TF_RUST_BUILD_FROM_SRC" == "true" ]]; then pip install --user numpy; fi
 
 script:
   - cargo test -vv -j 2 --features tensorflow_unstable
@@ -37,7 +38,6 @@ addons:
       - g++-4.9
       - gcc-4.9
       - oracle-java8-installer
-      - python-numpy
       - swig
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ env:
     - CC="gcc-4.9"
     - CXX="g++-4.9"
   matrix:
-    - TF_RUST_BUILD_FROM_SRC=true
+    # Building TensorFlow in Travis is not working properly, probably due
+    # to resources constraints.
+    # - TF_RUST_BUILD_FROM_SRC=true
     - TF_RUST_BUILD_FROM_SRC=false
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ cache:
   cargo: true
 
 rust: stable
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - CC="gcc-4.9"
+    - CXX="g++-4.9"
 
 install:
-  - export CC="gcc-4.9" CXX="g++-4.9"
   - source travis-ci/install.sh
 
 script:
-  - export RUST_BACKTRACE=1
   - cargo test -vv -j 2 --features tensorflow_unstable
   - cargo run --example regression
   - cargo run --features tensorflow_unstable --example expressions

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
     # - TF_RUST_BUILD_FROM_SRC=true
     - TF_RUST_BUILD_FROM_SRC=false
 
+os:
+  - linux
+  - osx
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ dist: trusty # still in beta, but required for the prebuilt TF binaries
 cache:
   cargo: true
 
-rust: stable
+rust:
+  - stable
+  - beta
+  - nightly
+
 env:
   global:
     - RUST_BACKTRACE=1


### PR DESCRIPTION
This PR adds will set Travis to follow Rust release train (stable/beta/nightly) on both Linux and OSX to increase the test platform coverage.

This should open the door to the addition of more tests, for example valgrind or sanitizers as described in #69.

Notes:
* Compilation of TensorFlow (`TF_RUST_BUILD_FROM_SRC=true`) is explicitly disabled as I have not been able to properly do so; bazel fails with `Server finished RPC without an explicit exit code` (see for example [here](https://travis-ci.org/nbigaouette-eai/rust/builds/212347865), more specifically [job 14.1](https://travis-ci.org/nbigaouette-eai/rust/jobs/212347866));
* Environment variables are moved to `env.global` instead of explicitly `export`ing them;
* Nightly rust are allowed to fail since the compiler itself can have regressions;
* The option `fast_finish` will let builds decide on success or failure even if those with `allow_failures` are not finished.
* numpy is installed using `pip` instead of `apt` as it's the recommended way of doing so.