### PR TITLE
Bump to tensorflow v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Adam Crume <acrume@google.com>"]
 description = "Rust language bindings for TensorFlow."
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ documentation = "https://tensorflow.github.io/rust/tensorflow"
 [dependencies]
 libc = "0.2"
 num-complex = { version = "0.1.35", default-features = false }
-tensorflow-sys = { version = "0.7.0", path = "tensorflow-sys" }
+tensorflow-sys = { version = "0.8.0", path = "tensorflow-sys" }
 
 [dev-dependencies]
 random = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Adam Crume <acrume@google.com>"]
 description = "Rust language bindings for TensorFlow."
 license = "Apache-2.0"

--- a/tensorflow-sys/Cargo.toml
+++ b/tensorflow-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow-sys"
-version = "0.7.0"
+version = "0.8.0"
 license = "Apache-2.0"
 authors = [
   "Adam Crume <acrume@google.com>",

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -22,8 +22,8 @@ const LIBRARY: &'static str = "tensorflow";
 const REPOSITORY: &'static str = "https://github.com/tensorflow/tensorflow.git";
 const TARGET: &'static str = "tensorflow:libtensorflow.so";
 // `VERSION` and `TAG` are separate because the tag is not always `'v' + VERSION`.
-const VERSION: &'static str = "1.0.0";
-const TAG: &'static str = "v1.0.0";
+const VERSION: &'static str = "1.1.0";
+const TAG: &'static str = "v1.1.0";
 const MIN_BAZEL: &'static str = "0.3.2";
 
 macro_rules! get(($name:expr) => (ok!(env::var($name))));

--- a/tensorflow-sys/src/bindgen.rs
+++ b/tensorflow-sys/src/bindgen.rs
@@ -26,11 +26,21 @@ pub const __STDC_ISO_10646__: ::std::os::raw::c_uint = 201505;
 pub const __STDC_NO_THREADS__: ::std::os::raw::c_uint = 1;
 pub const __GNU_LIBRARY__: ::std::os::raw::c_uint = 6;
 pub const __GLIBC__: ::std::os::raw::c_uint = 2;
-pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 24;
+pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 25;
 pub const _SYS_CDEFS_H: ::std::os::raw::c_uint = 1;
+pub const __glibc_c99_flexarr_available: ::std::os::raw::c_uint = 1;
 pub const __WORDSIZE: ::std::os::raw::c_uint = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: ::std::os::raw::c_uint = 1;
 pub const __SYSCALL_WORDSIZE: ::std::os::raw::c_uint = 64;
+pub const __GLIBC_USE_LIB_EXT2: ::std::os::raw::c_uint = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: ::std::os::raw::c_uint = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: ::std::os::raw::c_uint = 0;
+pub const _BITS_TYPES_H: ::std::os::raw::c_uint = 1;
+pub const _BITS_TYPESIZES_H: ::std::os::raw::c_uint = 1;
+pub const __OFF_T_MATCHES_OFF64_T: ::std::os::raw::c_uint = 1;
+pub const __INO_T_MATCHES_INO64_T: ::std::os::raw::c_uint = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: ::std::os::raw::c_uint = 1;
+pub const __FD_SETSIZE: ::std::os::raw::c_uint = 1024;
 pub const _BITS_WCHAR_H: ::std::os::raw::c_uint = 1;
 pub const INT8_MIN: ::std::os::raw::c_int = -128;
 pub const INT16_MIN: ::std::os::raw::c_int = -32768;
@@ -70,7 +80,80 @@ pub const SIZE_MAX: ::std::os::raw::c_int = -1;
 pub const WINT_MIN: ::std::os::raw::c_uint = 0;
 pub const WINT_MAX: ::std::os::raw::c_uint = 4294967295;
 pub type wchar_t = ::std::os::raw::c_int;
-pub type int_least8_t = ::std::os::raw::c_char;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
+pub type __int8_t = ::std::os::raw::c_schar;
+pub type __uint8_t = ::std::os::raw::c_uchar;
+pub type __int16_t = ::std::os::raw::c_short;
+pub type __uint16_t = ::std::os::raw::c_ushort;
+pub type __int32_t = ::std::os::raw::c_int;
+pub type __uint32_t = ::std::os::raw::c_uint;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+#[test]
+fn bindgen_test_layout___fsid_t() {
+    assert_eq!(::std::mem::size_of::<__fsid_t>() , 8usize , concat ! (
+               "Size of: " , stringify ! ( __fsid_t ) ));
+    assert_eq! (::std::mem::align_of::<__fsid_t>() , 4usize , concat ! (
+                "Alignment of " , stringify ! ( __fsid_t ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const __fsid_t ) ) . __val as * const _ as
+                usize } , 0usize , concat ! (
+                "Alignment of field: " , stringify ! ( __fsid_t ) , "::" ,
+                stringify ! ( __val ) ));
+}
+impl Clone for __fsid_t {
+    fn clone(&self) -> Self { *self }
+}
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __qaddr_t = *mut __quad_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type int_least8_t = ::std::os::raw::c_schar;
 pub type int_least16_t = ::std::os::raw::c_short;
 pub type int_least32_t = ::std::os::raw::c_int;
 pub type int_least64_t = ::std::os::raw::c_long;
@@ -78,7 +161,7 @@ pub type uint_least8_t = ::std::os::raw::c_uchar;
 pub type uint_least16_t = ::std::os::raw::c_ushort;
 pub type uint_least32_t = ::std::os::raw::c_uint;
 pub type uint_least64_t = ::std::os::raw::c_ulong;
-pub type int_fast8_t = ::std::os::raw::c_char;
+pub type int_fast8_t = ::std::os::raw::c_schar;
 pub type int_fast16_t = ::std::os::raw::c_long;
 pub type int_fast32_t = ::std::os::raw::c_long;
 pub type int_fast64_t = ::std::os::raw::c_long;
@@ -86,8 +169,8 @@ pub type uint_fast8_t = ::std::os::raw::c_uchar;
 pub type uint_fast16_t = ::std::os::raw::c_ulong;
 pub type uint_fast32_t = ::std::os::raw::c_ulong;
 pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 extern "C" {
     pub fn TF_Version() -> *const ::std::os::raw::c_char;
 }
@@ -142,7 +225,9 @@ pub enum TF_Code {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Status([u8; 0]);
+pub struct TF_Status {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewStatus() -> *mut TF_Status;
 }
@@ -209,7 +294,9 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Tensor([u8; 0]);
+pub struct TF_Tensor {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewTensor(arg1: TF_DataType, dims: *const i64,
                         num_dims: ::std::os::raw::c_int,
@@ -265,7 +352,9 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_SessionOptions([u8; 0]);
+pub struct TF_SessionOptions {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewSessionOptions() -> *mut TF_SessionOptions;
 }
@@ -283,7 +372,9 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Graph([u8; 0]);
+pub struct TF_Graph {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewGraph() -> *mut TF_Graph;
 }
@@ -292,10 +383,14 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_OperationDescription([u8; 0]);
+pub struct TF_OperationDescription {
+    _unused: [u8; 0],
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Operation([u8; 0]);
+pub struct TF_Operation {
+    _unused: [u8; 0],
+}
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct TF_Input {
@@ -780,7 +875,9 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_ImportGraphDefOptions([u8; 0]);
+pub struct TF_ImportGraphDefOptions {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewImportGraphDefOptions() -> *mut TF_ImportGraphDefOptions;
 }
@@ -795,6 +892,54 @@ extern "C" {
                                                  *const ::std::os::raw::c_char);
 }
 extern "C" {
+    pub fn TF_ImportGraphDefOptionsAddInputMapping(opts:
+                                                       *mut TF_ImportGraphDefOptions,
+                                                   src_name:
+                                                       *const ::std::os::raw::c_char,
+                                                   src_index:
+                                                       ::std::os::raw::c_int,
+                                                   dst: TF_Output);
+}
+extern "C" {
+    pub fn TF_GraphImportGraphDefOptionsRemapControlDependency(opts:
+                                                                   *mut TF_ImportGraphDefOptions,
+                                                               src_name:
+                                                                   *const ::std::os::raw::c_char,
+                                                               dst:
+                                                                   *mut TF_Operation);
+}
+extern "C" {
+    pub fn TF_ImportGraphDefOptionsAddControlDependency(opts:
+                                                            *mut TF_ImportGraphDefOptions,
+                                                        oper:
+                                                            *mut TF_Operation);
+}
+extern "C" {
+    pub fn TF_ImportGraphDefOptionsAddReturnOutput(opts:
+                                                       *mut TF_ImportGraphDefOptions,
+                                                   oper_name:
+                                                       *const ::std::os::raw::c_char,
+                                                   index:
+                                                       ::std::os::raw::c_int);
+}
+extern "C" {
+    pub fn TF_ImportGraphDefOptionsNumReturnOutputs(opts:
+                                                        *const TF_ImportGraphDefOptions)
+     -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn TF_GraphImportGraphDefWithReturnOutputs(graph: *mut TF_Graph,
+                                                   graph_def:
+                                                       *const TF_Buffer,
+                                                   options:
+                                                       *const TF_ImportGraphDefOptions,
+                                                   return_outputs:
+                                                       *mut TF_Output,
+                                                   num_return_outputs:
+                                                       ::std::os::raw::c_int,
+                                                   status: *mut TF_Status);
+}
+extern "C" {
     pub fn TF_GraphImportGraphDef(graph: *mut TF_Graph,
                                   graph_def: *const TF_Buffer,
                                   options: *const TF_ImportGraphDefOptions,
@@ -806,8 +951,84 @@ extern "C" {
                                  status: *mut TF_Status);
 }
 #[repr(C)]
+#[derive(Debug, Copy)]
+pub struct TF_WhileParams {
+    pub ninputs: ::std::os::raw::c_int,
+    pub cond_graph: *const TF_Graph,
+    pub cond_inputs: *const TF_Output,
+    pub cond_output: TF_Output,
+    pub body_graph: *const TF_Graph,
+    pub body_inputs: *const TF_Output,
+    pub body_outputs: *const TF_Output,
+    pub name: *const ::std::os::raw::c_char,
+}
+#[test]
+fn bindgen_test_layout_TF_WhileParams() {
+    assert_eq!(::std::mem::size_of::<TF_WhileParams>() , 72usize , concat ! (
+               "Size of: " , stringify ! ( TF_WhileParams ) ));
+    assert_eq! (::std::mem::align_of::<TF_WhileParams>() , 8usize , concat ! (
+                "Alignment of " , stringify ! ( TF_WhileParams ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . ninputs as * const _
+                as usize } , 0usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( ninputs ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . cond_graph as *
+                const _ as usize } , 8usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( cond_graph ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . cond_inputs as *
+                const _ as usize } , 16usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( cond_inputs ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . cond_output as *
+                const _ as usize } , 24usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( cond_output ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . body_graph as *
+                const _ as usize } , 40usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( body_graph ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . body_inputs as *
+                const _ as usize } , 48usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( body_inputs ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . body_outputs as *
+                const _ as usize } , 56usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( body_outputs ) ));
+    assert_eq! (unsafe {
+                & ( * ( 0 as * const TF_WhileParams ) ) . name as * const _ as
+                usize } , 64usize , concat ! (
+                "Alignment of field: " , stringify ! ( TF_WhileParams ) , "::"
+                , stringify ! ( name ) ));
+}
+impl Clone for TF_WhileParams {
+    fn clone(&self) -> Self { *self }
+}
+extern "C" {
+    pub fn TF_NewWhile(g: *mut TF_Graph, inputs: *mut TF_Output,
+                       ninputs: ::std::os::raw::c_int, status: *mut TF_Status)
+     -> TF_WhileParams;
+}
+extern "C" {
+    pub fn TF_FinishWhile(params: *const TF_WhileParams,
+                          status: *mut TF_Status, outputs: *mut TF_Output);
+}
+extern "C" {
+    pub fn TF_AbortWhile(params: *const TF_WhileParams);
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Session([u8; 0]);
+pub struct TF_Session {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewSession(graph: *mut TF_Graph, opts: *const TF_SessionOptions,
                          status: *mut TF_Status) -> *mut TF_Session;
@@ -869,9 +1090,14 @@ extern "C" {
                           ntargets: ::std::os::raw::c_int,
                           arg2: *mut TF_Status);
 }
+extern "C" {
+    pub fn TF_DeletePRunHandle(handle: *const ::std::os::raw::c_char);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_DeprecatedSession([u8; 0]);
+pub struct TF_DeprecatedSession {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_NewDeprecatedSession(arg1: *const TF_SessionOptions,
                                    status: *mut TF_Status)
@@ -933,7 +1159,9 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TF_Library([u8; 0]);
+pub struct TF_Library {
+    _unused: [u8; 0],
+}
 extern "C" {
     pub fn TF_LoadLibrary(library_filename: *const ::std::os::raw::c_char,
                           status: *mut TF_Status) -> *mut TF_Library;


### PR DESCRIPTION
Bump the `tensorflow-sys` wrapper to 1.1.0.

The script `generate_bindgen_rs.sh` was used (which simply executes `bindgen --blacklist-type max_align_t target/libtensorflow-cpu-linux-x86_64-1.1.0/include/tensorflow/c/c_api.h --output src/bindgen.rs`).

Note that I also bumped the `-sys` crate version to 0.8.0 and the main one to 0.3.2. Hopefully this is the proper way?