### PR TITLE
Fix a memory leak in Buffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -86,7 +86,7 @@ impl<T: TensorType> Buffer<T> {
         (*inner).length = len;
         Buffer {
             inner: inner,
-            owned: false,
+            owned: true,
             phantom: PhantomData,
         }
     }
@@ -96,8 +96,7 @@ impl<T: TensorType> Buffer<T> {
     /// The caller is responsible for freeing the data.
     pub unsafe fn into_ptr(mut self) -> (*mut T, usize) {
         // TODO: remove
-        // This flag is used by drop.
-        self.owned = false;
+        (*self.inner).data_deallocator = None;
         (self.data_mut(), self.length())
     }
 
@@ -128,7 +127,8 @@ impl<T: TensorType> Buffer<T> {
     /// Creates a buffer from data owned by the C API.
     ///
     /// `len` is the number of elements.
-    /// The underlying data is freed when the buffer is destroyed if `owned` is true.
+    /// The underlying data is freed when the buffer is destroyed if `owned`
+    /// is true and the `buf` has a data deallocator.
     pub unsafe fn from_c(buf: *mut tf::TF_Buffer, owned: bool) -> Self {
         Buffer {
             inner: buf,


### PR DESCRIPTION
The Buffer type seems to conflate ownership of the TF_Buffer object and the
ownership of the data wrapped by the TF_Buffer object.

A TF_Buffer object created through from_ptr() is created as 'borrowed'. As
a result, the TF_Buffer object is not deallocated, leadning to a memory
leak.

This commit makes two small changes to (hopefully) remedy the leak:

- from_ptr() sets the TF_Buffer to be owned, so that the drop() will
  deallocate the TF_Buffer object. Since the TF_Buffer does not have
  a data_deallocator set, the data is not freed when Buffer is dropped.
- into_ptr() does not change the TF_Buffer ownership, but instead sets
  data_deallocator to NULL. As a consequence, the caller becomes responsible
  for freeing the data and the TF_Buffer is deallocated by drop().