### PR TITLE
Make sure TF version matches in crates' files

### DIFF
--- a/run-valgrind
+++ b/run-valgrind
@@ -12,7 +12,7 @@ set -e
 
 cd $(dirname $(readlink -f "$0"))
 
-tensorflow_version=1.1.0
+tensorflow_version=1.2.1
 
 valgrind_log=valgrind.log
 truncate --size=0 "$valgrind_log"

--- a/test-all
+++ b/test-all
@@ -2,6 +2,18 @@
 
 set -e
 
+# Make sure the Tensorflow version in the -sys build script matches the one in
+# the run-valgrind script.
+version_build_script=`grep "const VERSION" tensorflow-sys/build.rs | sed 's|.*"\([0-9\.]*\)";|\1|g'`
+version_run_valgrind=`grep "tensorflow_version=" run-valgrind | sed "s|.*=\(.*\)|\1|g"`
+if [[ "${version_build_script}" != "${version_run_valgrind}" ]]; then
+    echo "ERROR: Tensorflow version specified in build script does not match the one in the"
+    echo "       valgrind run script."
+    echo "       tensorflow-sys/build.rs: ${version_build_script}"
+    echo "       run-valgrind: ${version_run_valgrind}"
+    exit 1
+fi
+
 cargo test -vv -j 2 --features tensorflow_unstable
 cargo run --example regression
 cargo run --features tensorflow_unstable --example expressions


### PR DESCRIPTION
Add a check in `test-all` to verify the TF versions in different location

The `run-valgrind` script fails silently if its Tensorflow version is not
the proper one. The reason is because the `export LD_LIBRARY_PATH` line
explicitly uses the TF version in the exported path. If it is wrong (for
example if the version defined in variable `tensorflow_version` near the
top of the file) then the first call to valgrind will fail.

All the output of the call to valgrind is sent to a log file, so the
failure is not reported. And since the first line of the script let it
abort on error (`set -e`), the script stop on the first call to valgrind.

This commit adds a check in the `test-all` script to make sure the version
values match where they appear. This should let the CI fail if the
TF versioning is wrong in the crates.

EDIT: The first commit should fail the CI due to the bad version match. Next commit should fix this.
EDIT: CI does fails: https://travis-ci.org/tensorflow/rust/jobs/260612680#L746-L747
```
$ ./test-all
ERROR: Tensorflow version specified in build script does not match the one in the
       valgrind run script.
       tensorflow-sys/build.rs: 1.2.1
       run-valgrind: 1.1.0
```
EDIT: CI passes! 😄 