### PR TITLE
A few tweaks to allow building on Windows

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -569,15 +569,6 @@ pub struct Input<'a> {
     pub index: c_int,
 }
 
-impl<'a> Input<'a> {
-    fn to_c(&self) -> tf::TF_Input {
-        tf::TF_Input {
-            oper: self.operation.inner,
-            index: self.index,
-        }
-    }
-}
-
 ////////////////////////
 
 /// A `Output` is one end of a graph edge.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,12 @@
         unused_import_braces,
         unused_qualifications)]
 
+#![cfg_attr(windows, feature(alloc, allocator_api))]
+
 extern crate libc;
 extern crate num_complex;
 extern crate tensorflow_sys as tf;
+#[cfg(windows)] extern crate alloc;
 
 use libc::{c_int, c_uint};
 use num_complex::Complex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,7 +738,7 @@ impl TensorType for String {
     }
 
     fn pack(data: &[Self], buffer: &mut [u8]) -> Result<()> {
-        let mut offsets: &mut [u64] =
+        let offsets: &mut [u64] =
             unsafe { slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut u64, data.len()) };
         let base_offset = mem::size_of::<u64>() * data.len();
         let mut offset = base_offset;
@@ -916,7 +916,7 @@ impl<T: TensorType> AnyTensor for Tensor<T> {
                     self.dims.len() as c_int,
                     packed_size,
                 );
-                let mut buf =
+                let buf =
                     slice::from_raw_parts_mut(tf::TF_TensorData(inner) as *mut u8, packed_size);
                 T::pack(data, buf)?;
                 inner

--- a/src/session.rs
+++ b/src/session.rs
@@ -332,7 +332,7 @@ impl<'l> StepWithGraph<'l> {
     }
 
     fn drop_output_tensors(&mut self) {
-        for mut tensor in &mut self.output_tensors {
+        for tensor in &mut self.output_tensors {
             // TODO: Is TF_DeleteTensor NULL safe?
             if !tensor.is_null() {
                 unsafe {

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -36,6 +36,11 @@ macro_rules! log {
 macro_rules! log_var(($var:ident) => (log!(concat!(stringify!($var), " = {:?}"), $var)));
 
 fn main() {
+    if let Ok(prebuilt) = env::var("TF_RUST_PREBUILT_DIR") {
+        use_prebuilt(&PathBuf::from(prebuilt));
+        return;
+    }
+
     if pkg_config::find_library(LIBRARY).is_ok() {
         log!("Returning early because {} was already found", LIBRARY);
         return;
@@ -255,4 +260,11 @@ fn check_bazel() -> Result<(), Box<Error>> {
         return Err("Did not find version number in `bazel version` output.".into());
     }
     Ok(())
+}
+
+fn use_prebuilt(path: &Path) {
+    log!("Using prebuilt at {}", path.display());
+
+    println!("cargo:rustc-link-lib=dylib={}", LIBRARY);
+    println!("cargo:rustc-link-search={}", path.display());
 }


### PR DESCRIPTION
I wanted to get this to work on Windows because it's my preferred dev environment.

Building Tensorflow from source on Windows is not supported and extremely difficult, but fortunately it's still possible to steal the binaries from the official `pip` installation and link them with this wrapper (with enough magic).

This PR lets you define a `TF_RUST_PREBUILT_DIR` env variable that points to a folder containing `tensorflow.dll` and `tensorflow.lib` that will be used by `build.rs` to link. This could possibly be useful on other platforms as well if you don't want to `install` the binaries you built yourself.

I've also changed `buffer.rs` to require Nightly (but only on Windows) in order to replace `posix_memalign`. 

From my tests with the examples, everything seems to work alright. I don't mind if you prefer not to integrate this, but I thought it could be useful to someone else!
It's not particularly clean but it makes setting up on Windows at least possible.