### PR TITLE
Update to TensorFlow v1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://tensorflow.github.io/rust/tensorflow"
 [dependencies]
 libc = "0.2"
 num-complex = { version = "0.1.35", default-features = false }
-tensorflow-sys = { version = "0.8.0", path = "tensorflow-sys" }
+tensorflow-sys = { version = "0.9.0", path = "tensorflow-sys" }
 
 [dev-dependencies]
 random = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Adam Crume <acrume@google.com>"]
 description = "Rust language bindings for TensorFlow."
 license = "Apache-2.0"

--- a/run-valgrind
+++ b/run-valgrind
@@ -12,7 +12,7 @@ set -e
 
 cd $(dirname $(readlink -f "$0"))
 
-tensorflow_version=1.2.1
+tensorflow_version=1.3.0
 
 valgrind_log=valgrind.log
 truncate --size=0 "$valgrind_log"

--- a/tensorflow-sys/Cargo.toml
+++ b/tensorflow-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow-sys"
-version = "0.8.0"
+version = "0.9.0"
 license = "Apache-2.0"
 authors = [
   "Adam Crume <acrume@google.com>",

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -22,8 +22,8 @@ const LIBRARY: &'static str = "tensorflow";
 const REPOSITORY: &'static str = "https://github.com/tensorflow/tensorflow.git";
 const TARGET: &'static str = "tensorflow:libtensorflow.so";
 // `VERSION` and `TAG` are separate because the tag is not always `'v' + VERSION`.
-const VERSION: &'static str = "1.2.1";
-const TAG: &'static str = "v1.2.1";
+const VERSION: &'static str = "1.3.0";
+const TAG: &'static str = "v1.3.0";
 const MIN_BAZEL: &'static str = "0.3.2";
 
 macro_rules! get(($name:expr) => (ok!(env::var($name))));

--- a/tensorflow-sys/src/bindgen.rs
+++ b/tensorflow-sys/src/bindgen.rs
@@ -22,11 +22,11 @@ pub const __USE_FORTIFY_LEVEL: ::std::os::raw::c_uint = 0;
 pub const _STDC_PREDEF_H: ::std::os::raw::c_uint = 1;
 pub const __STDC_IEC_559__: ::std::os::raw::c_uint = 1;
 pub const __STDC_IEC_559_COMPLEX__: ::std::os::raw::c_uint = 1;
-pub const __STDC_ISO_10646__: ::std::os::raw::c_uint = 201605;
+pub const __STDC_ISO_10646__: ::std::os::raw::c_uint = 201505;
 pub const __STDC_NO_THREADS__: ::std::os::raw::c_uint = 1;
 pub const __GNU_LIBRARY__: ::std::os::raw::c_uint = 6;
 pub const __GLIBC__: ::std::os::raw::c_uint = 2;
-pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 24;
+pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 23;
 pub const _SYS_CDEFS_H: ::std::os::raw::c_uint = 1;
 pub const __WORDSIZE: ::std::os::raw::c_uint = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: ::std::os::raw::c_uint = 1;
@@ -1082,6 +1082,45 @@ extern "C" {
                    noutputs: ::std::os::raw::c_int,
                    target_oper_names: *mut *const ::std::os::raw::c_char,
                    ntargets: ::std::os::raw::c_int, arg2: *mut TF_Status);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TF_DeviceList {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn TF_SessionListDevices(session: *mut TF_Session,
+                                 status: *mut TF_Status)
+     -> *mut TF_DeviceList;
+}
+extern "C" {
+    pub fn TF_DeprecatedSessionListDevices(session: *mut TF_DeprecatedSession,
+                                           status: *mut TF_Status)
+     -> *mut TF_DeviceList;
+}
+extern "C" {
+    pub fn TF_DeleteDeviceList(list: *mut TF_DeviceList);
+}
+extern "C" {
+    pub fn TF_DeviceListCount(list: *const TF_DeviceList)
+     -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn TF_DeviceListName(list: *const TF_DeviceList,
+                             index: ::std::os::raw::c_int,
+                             arg1: *mut TF_Status)
+     -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn TF_DeviceListType(list: *const TF_DeviceList,
+                             index: ::std::os::raw::c_int,
+                             arg1: *mut TF_Status)
+     -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn TF_DeviceListMemoryBytes(list: *const TF_DeviceList,
+                                    index: ::std::os::raw::c_int,
+                                    arg1: *mut TF_Status) -> i64;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR updates TensorFlow to v1.3.0. The creates' version are bumped to 0.6.0 and 0.9.0.

I ran `test-all` with success, but could not run `run-valgrind` since it seems tensorflow needs to be rebuilt (difficult on my current machine).