### PR TITLE
Tweaks for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://tensorflow.github.io/rust/tensorflow"
 
 [dependencies]
 libc = "0.2"
+aligned_alloc = "0.1"
 num-complex = { version = "0.1.40", default-features = false }
 tensorflow-sys = { version = "0.9.0", path = "tensorflow-sys" }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -68,7 +68,6 @@ impl<T: TensorType> Buffer<T> {
             if len > 0 {
                 panic!("Failed to allocate {} aligned by {}", alloc_size, align);
             }
-            (*inner).data_deallocator = Some(do_nothing);
         } else {
             (*inner).data_deallocator = Some(deallocator);
         }
@@ -145,9 +144,6 @@ impl<T: TensorType> BufferTrait for Buffer<T> {
 
 unsafe extern "C" fn deallocator(data: *mut std_c_void, _length: size_t) {
     aligned_alloc::aligned_free(data as *mut ());
-}
-
-unsafe extern "C" fn do_nothing(data: *mut std_c_void, _length: size_t) {
 }
 
 impl<T: TensorType> Drop for Buffer<T> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,5 @@
 extern crate tensorflow_sys as tf;
+extern crate aligned_alloc;
 
 use libc;
 use libc::c_void;
@@ -59,16 +60,20 @@ impl<T: TensorType> Buffer<T> {
         // posix_memalign requires the alignment to be at least sizeof(void*).
         // TODO: Use alloc::heap::allocate once it's stable, or at least
         // libc::aligned_alloc once it exists
-        let mut ptr = ptr::null::<c_void>() as *mut c_void;
-        let err = libc::posix_memalign(&mut ptr, align, alloc_size);
-        if err != 0 {
-            let c_msg = libc::strerror(err);
-            let msg = CStr::from_ptr(c_msg);
-            panic!("Failed to allocate: {}", msg.to_str().unwrap());
+        let mut ptr = aligned_alloc::aligned_alloc(alloc_size, align);
+
+        // We cannot be sure that we can deallocate always.
+        // For Linux it would be OK, but for Windows it's not.
+        if ptr.is_null() {
+            if len > 0 {
+                panic!("Failed to allocate {} aligned by {}", alloc_size, align);
+            }
+            (*inner).data_deallocator = Some(do_nothing);
+        } else {
+            (*inner).data_deallocator = Some(deallocator);
         }
         (*inner).data = ptr as *mut std_c_void;
         (*inner).length = len;
-        (*inner).data_deallocator = Some(deallocator);
         Buffer {
             inner: inner,
             owned: true,
@@ -139,7 +144,10 @@ impl<T: TensorType> BufferTrait for Buffer<T> {
 }
 
 unsafe extern "C" fn deallocator(data: *mut std_c_void, _length: size_t) {
-    libc::free(data as *mut c_void);
+    aligned_alloc::aligned_free(data as *mut ());
+}
+
+unsafe extern "C" fn do_nothing(data: *mut std_c_void, _length: size_t) {
 }
 
 impl<T: TensorType> Drop for Buffer<T> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -64,12 +64,10 @@ impl<T: TensorType> Buffer<T> {
 
         // We cannot be sure that we can deallocate always.
         // For Linux it would be OK, but for Windows it's not.
-        if ptr.is_null() {
-            if len > 0 {
-                panic!("Failed to allocate {} aligned by {}", alloc_size, align);
-            }
-        } else {
+        if !ptr.is_null() {
             (*inner).data_deallocator = Some(deallocator);
+        } else if len > 0 {
+            panic!("Failed to allocate {} aligned by {}", alloc_size, align);
         }
         (*inner).data = ptr as *mut std_c_void;
         (*inner).length = len;

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -20,7 +20,6 @@ use tar::Archive;
 
 const FRAMEWORK_LIBRARY: &'static str = "tensorflow_framework";
 const LIBRARY: &'static str = "tensorflow";
-const WINDOWS_LIB: &'static str = "tensorflow.lib";
 const REPOSITORY: &'static str = "https://github.com/tensorflow/tensorflow.git";
 const FRAMEWORK_TARGET: &'static str = "tensorflow:libtensorflow_framework.so";
 const TARGET: &'static str = "tensorflow:libtensorflow.so";
@@ -40,7 +39,7 @@ macro_rules! log_var(($var:ident) => (log!(concat!(stringify!($var), " = {:?}"),
 
 fn main() {
     if check_windows_lib() {
-        log!("Returning early because {} was already found", WINDOWS_LIB);
+        log!("Returning early because {} was already found", LIBRARY);
         return;
     }
 
@@ -68,9 +67,10 @@ fn check_windows_lib() -> bool {
 
 #[cfg(target_env = "msvc")]
 fn check_windows_lib() -> bool {
+    let windows_lib: &str = &format!("{}.lib", LIBRARY);
     if let Ok(path) = env::var("PATH") {
         for p in path.split(";") {
-            let path = Path::new(p).join(WINDOWS_LIB);
+            let path = Path::new(p).join(windows_lib);
             if path.exists() {
                 println!("cargo:rustc-link-lib=dylib={}", LIBRARY);
                 println!("cargo:rustc-link-search=native={}", p);


### PR DESCRIPTION
I made some tweaks for Windows, without knowing that #100 already exists. It seems to take a while until that pr gets merged, so I open another.

Used lib file generated with https://github.com/bekker/tensorflow-windows-lib.

Basically same as #100, except:
1) For `posix_memalign`, use [external crate](https://github.com/jonas-schievink/aligned_alloc.rs), not nightly features. Therefore works with the stable rust. The crate is essentially same for Posix, but some evil tweaks for Windows.

2) Find `tensorflow.lib` from `PATH` environment variable and use it, rather than defining custom env var.

I wrote a simple mnist model with CNN and it worked well with cuda enabled.