### PR TITLE
dimension should be [] for scalar tensors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,7 +973,7 @@ impl<T: TensorType> DerefMut for Tensor<T> {
 
 impl<T: TensorType> From<T> for Tensor<T> {
     fn from(value: T) -> Self {
-        let mut tensor = Tensor::new(&[1]);
+        let mut tensor = Tensor::new(&[]);
         tensor[0] = value;
         tensor
     }


### PR DESCRIPTION
Consider the following:
```python
learning_rate = tf.placeholder(tf.float32, name="learning_rate")
train = tf.train.AdamOptimizer(learning_rate).minimize(cost, name="train")
```
```rust
let op_learning_rate = graph.operation_by_name_required("learning_rate")?;
let mut learning_rate = Tensor::from(0.003f32);
train_step.add_input(&op_learning_rate, 0, &learning_rate);
```

Current `From<T> for Tensor<T>` implementation initializes tensor with dimension of `[1]`. That way `TensorShapeUtils::IsScalar` returns false, therefore code above panics.

So I propose to change `From<T> for Tensor<T>` impl, which seems to be for scalar tensor initializtion, to use dim `[]`.

It works well for tests and my personal projects, but will there any implications / errors?