### PR TITLE
Add most bindings new in TensorFlow 1.4

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1009,6 +1009,24 @@ impl<'a> OperationDescription<'a> {
 
 ////////////////////////
 
+/// Options that can be passed during function creation.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct FunctionOptions {
+    inner: *mut tf::TF_FunctionOptions,
+}
+
+impl FunctionOptions {
+    /// Creates a blank set of options.
+    fn new() -> Self {
+        FunctionOptions {
+            inner: ptr::null_mut(), // TODO: Use real options when they become available
+        }
+    }
+}
+
+////////////////////////
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1066,6 +1066,25 @@ impl Function {
             Ok(Function { inner })
         }
     }
+
+    /// Sets function attribute named `attr_name` to value stored in `proto`. If
+    /// this attribute is already set to another value, it is overriden. `proto`
+    /// should be a sequence of bytes representing a binary serialization of an
+    /// AttrValue protocol buffer.
+    pub fn set_attr_value_proto(&mut self, attr_name: &str, proto: &[u8]) -> Result<()> {
+        let status = Status::new();
+        let attr_name_cstr = CString::new(attr_name)?;
+        unsafe {
+            tf::TF_FunctionSetAttrValueProto(
+                self.inner,
+                attr_name_cstr.as_ptr(),
+                proto.as_ptr() as *const std_c_void,
+                proto.len(),
+                status.inner,
+            );
+        }
+        status.into_result()
+    }
 }
 
 ////////////////////////

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1051,6 +1051,21 @@ impl Function {
             Ok(buf.into())
         }
     }
+
+    /// Construct and return the function whose FunctionDef representation is
+    /// serialized in `proto`. Returns a newly created `Function` instance.
+    pub fn import_function_def(proto: &[u8]) -> Result<Function> {
+        let status = Status::new();
+        unsafe {
+            let inner = tf::TF_FunctionImportFunctionDef(
+                proto.as_ptr() as *const std_c_void,
+                proto.len(),
+                status.inner,
+            );
+            status.into_result()?;
+            Ok(Function { inner })
+        }
+    }
 }
 
 ////////////////////////

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1037,6 +1037,22 @@ pub struct Function {
 
 impl_drop!(Function, TF_DeleteFunction);
 
+impl Function {
+    /// Returns a serialized representation of the function (as a FunctionDef
+    /// protocol message).
+    ///
+    /// May fail on very large graphs in the future.
+    pub fn to_function_def(&self) -> Result<Vec<u8>> {
+        let status = Status::new();
+        unsafe {
+            let mut buf = Buffer::from_ptr(ptr::null_mut(), 0);
+            tf::TF_FunctionToFunctionDef(self.inner, buf.inner_mut(), status.inner);
+            status.into_result()?;
+            Ok(buf.into())
+        }
+    }
+}
+
 ////////////////////////
 
 #[cfg(test)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1027,6 +1027,18 @@ impl FunctionOptions {
 
 ////////////////////////
 
+/// Function is a grouping of operations with defined inputs and outputs.
+/// Once created and added to graphs, functions can be invoked by creating an
+/// operation whose operation type matches the function name.
+#[derive(Debug)]
+pub struct Function {
+    inner: *mut tf::TF_Function,
+}
+
+impl_drop!(Function, TF_DeleteFunction);
+
+////////////////////////
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1085,6 +1085,25 @@ impl Function {
         }
         status.into_result()
     }
+
+    /// Returns the binary-serialized AttrValue proto representation of the
+    /// value of the `attr_name` attr of the function. If `attr_name` attribute
+    /// is not present, returns an error.
+    pub fn get_attr_value_proto(&self, attr_name: &str) -> Result<Vec<u8>> {
+        let status = Status::new();
+        let attr_name_cstr = CString::new(attr_name)?;
+        unsafe {
+            let mut buf = Buffer::from_ptr(ptr::null_mut(), 0);
+            tf::TF_FunctionGetAttrValueProto(
+                self.inner,
+                attr_name_cstr.as_ptr(),
+                buf.inner_mut(),
+                status.inner,
+            );
+            status.into_result()?;
+            Ok(buf.into())
+        }
+    }
 }
 
 ////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,9 @@ c_enum!("Type of a single tensor element.", TF_DataType, DataType {
 
   /// TensorFlow Resource (name, container, device,...)
   value Resource = 20,
+
+  /// A dynamic type similar to std::any::Any.
+  value Variant = 21,
 });
 
 ////////////////////////

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -222,12 +222,20 @@ fn build_from_src() {
                 .arg("yes ''|./configure"));
             File::create(configure_hint_file).unwrap();
         }
+        // Allows us to pass in --incompatible_load_argument_is_label=false
+        // to work around https://github.com/tensorflow/tensorflow/issues/15492
+        let bazel_args_string = if let Ok(args) = env::var("TF_RUST_BAZEL_OPTS") {
+            args
+        } else {
+            "".to_string()
+        };
         run("bazel", |command| {
             command.current_dir(&source)
                 .arg("build")
                 .arg(format!("--jobs={}", get!("NUM_JOBS")))
                 .arg("--compilation_mode=opt")
                 .arg("--copt=-march=native")
+                .args(bazel_args_string.split_whitespace())
                 .arg(TARGET)
         });
         let framework_target_bazel_bin = source.join("bazel-bin").join(framework_target_path);

--- a/tensorflow-sys/src/bindgen.rs
+++ b/tensorflow-sys/src/bindgen.rs
@@ -22,11 +22,11 @@ pub const __USE_FORTIFY_LEVEL: ::std::os::raw::c_uint = 0;
 pub const _STDC_PREDEF_H: ::std::os::raw::c_uint = 1;
 pub const __STDC_IEC_559__: ::std::os::raw::c_uint = 1;
 pub const __STDC_IEC_559_COMPLEX__: ::std::os::raw::c_uint = 1;
-pub const __STDC_ISO_10646__: ::std::os::raw::c_uint = 201505;
+pub const __STDC_ISO_10646__: ::std::os::raw::c_uint = 201605;
 pub const __STDC_NO_THREADS__: ::std::os::raw::c_uint = 1;
 pub const __GNU_LIBRARY__: ::std::os::raw::c_uint = 6;
 pub const __GLIBC__: ::std::os::raw::c_uint = 2;
-pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 23;
+pub const __GLIBC_MINOR__: ::std::os::raw::c_uint = 24;
 pub const _SYS_CDEFS_H: ::std::os::raw::c_uint = 1;
 pub const __WORDSIZE: ::std::os::raw::c_uint = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: ::std::os::raw::c_uint = 1;
@@ -115,6 +115,7 @@ pub enum TF_DataType {
     TF_COMPLEX128 = 18,
     TF_HALF = 19,
     TF_RESOURCE = 20,
+    TF_VARIANT = 21,
 }
 extern "C" {
     pub fn TF_DataTypeSize(dt: TF_DataType) -> usize;
@@ -362,6 +363,16 @@ fn bindgen_test_layout_TF_Output() {
 }
 impl Clone for TF_Output {
     fn clone(&self) -> Self { *self }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TF_Function {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TF_FunctionOptions {
+    _unused: [u8; 0],
 }
 extern "C" {
     pub fn TF_GraphSetTensorShape(graph: *mut TF_Graph, output: TF_Output,
@@ -866,6 +877,11 @@ extern "C" {
                                   status: *mut TF_Status);
 }
 extern "C" {
+    pub fn TF_GraphCopyFunction(g: *mut TF_Graph, func: *const TF_Function,
+                                grad: *const TF_Function,
+                                status: *mut TF_Status);
+}
+extern "C" {
     pub fn TF_OperationToNodeDef(oper: *mut TF_Operation,
                                  output_node_def: *mut TF_Buffer,
                                  status: *mut TF_Status);
@@ -949,6 +965,51 @@ extern "C" {
                            ny: ::std::os::raw::c_int, x: *mut TF_Output,
                            nx: ::std::os::raw::c_int, dx: *mut TF_Output,
                            status: *mut TF_Status, dy: *mut TF_Output);
+}
+extern "C" {
+    pub fn TF_GraphToFunction(fn_body: *const TF_Graph,
+                              fn_name: *const ::std::os::raw::c_char,
+                              append_hash_to_fn_name: ::std::os::raw::c_uchar,
+                              num_opers: ::std::os::raw::c_int,
+                              opers: *const *const TF_Operation,
+                              ninputs: ::std::os::raw::c_int,
+                              inputs: *const TF_Output,
+                              noutputs: ::std::os::raw::c_int,
+                              outputs: *const TF_Output,
+                              output_names:
+                                  *const *const ::std::os::raw::c_char,
+                              opts: *const TF_FunctionOptions,
+                              description: *const ::std::os::raw::c_char,
+                              status: *mut TF_Status) -> *mut TF_Function;
+}
+extern "C" {
+    pub fn TF_FunctionToFunctionDef(func: *mut TF_Function,
+                                    output_func_def: *mut TF_Buffer,
+                                    status: *mut TF_Status);
+}
+extern "C" {
+    pub fn TF_FunctionImportFunctionDef(proto: *const ::std::os::raw::c_void,
+                                        proto_len: usize,
+                                        status: *mut TF_Status)
+     -> *mut TF_Function;
+}
+extern "C" {
+    pub fn TF_FunctionSetAttrValueProto(func: *mut TF_Function,
+                                        attr_name:
+                                            *const ::std::os::raw::c_char,
+                                        proto: *const ::std::os::raw::c_void,
+                                        proto_len: usize,
+                                        status: *mut TF_Status);
+}
+extern "C" {
+    pub fn TF_FunctionGetAttrValueProto(func: *mut TF_Function,
+                                        attr_name:
+                                            *const ::std::os::raw::c_char,
+                                        output_attr_value: *mut TF_Buffer,
+                                        status: *mut TF_Status);
+}
+extern "C" {
+    pub fn TF_DeleteFunction(func: *mut TF_Function);
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Still missing Graph::to_function (#118), but I wanted to get what was done pushed.