### PR TITLE
Stop installing gcc on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ rust:
 env:
   global:
     - RUST_BACKTRACE=1
-    - CC="gcc-4.9"
-    - CXX="g++-4.9"
+    # - CC="gcc-4.9"
+    # - CXX="g++-4.9"
   matrix:
     # Building TensorFlow in Travis is not working properly, probably due
     # to resources constraints.
@@ -45,8 +45,9 @@ addons:
       - ubuntu-toolchain-r-test
 
     packages:
-      - g++-4.9
-      - gcc-4.9
+      # Re-enable if we ever re-enable building from source on Travis. Only needed for building TensorFlow itself, not the Rust bindings.
+      # - g++-4.9
+      # - gcc-4.9
       - oracle-java8-installer
       - swig
 


### PR DESCRIPTION
This is a workaround for not finding gcc 4.9 on OSX.  Since we're not building from source on Travis anyway, we don't need gcc, so we can just avoid installing it.

Fixes: #116