### PR TITLE
add feature flag to enable gpu support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tensorflow-sys = { version = "0.9.0", path = "tensorflow-sys" }
 random = "0.12"
 
 [features]
+tensorflow_gpu = ["tensorflow-sys/tensorflow_gpu"]
 tensorflow_unstable = []
 # This is for testing purposes; users should not use this.
 nightly = []


### PR DESCRIPTION
I added a feature flag to enable GPU support in tensorflow-sys. Not why it wasn't already there, so feel free to reject for sensible reasons.