### PR TITLE
Thread-safe tensors for C-compatible types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,13 +868,6 @@ where
     }
 }
 
-impl<T> TensorDataCRepr<T>
-where
-    T: TensorType,
-{
-    fn drop_tensor(&mut self) {}
-}
-
 impl<T: TensorType> Deref for TensorDataCRepr<T> {
     type Target = [T];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,6 +805,9 @@ where
     phantom: PhantomData<T>,
 }
 
+unsafe impl<T> Send for TensorDataCRepr<T> where T: TensorType {}
+unsafe impl<T> Sync for TensorDataCRepr<T> where T: TensorType {}
+
 impl<T: TensorType> Drop for TensorDataCRepr<T> {
     fn drop(&mut self) {
         if !self.inner.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,7 +866,7 @@ where
         })
     }
 
-    fn as_mut_ptr(&self, dims: &Vec<u64>) -> Result<*mut tf::TF_Tensor> {
+    fn as_mut_ptr(&self, _dims: &Vec<u64>) -> Result<*mut tf::TF_Tensor> {
         assert!(!self.inner.is_null());
         Ok(self.inner)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,15 +778,19 @@ trait AnyTensor: Debug {
 
 ////////////////////////
 
-trait TensorInner<T>: Debug
+/// Inner representation of `Tensor`s.
+pub trait TensorInner<T>: Debug
 where
     Self: Sized + Deref<Target = [T]> + DerefMut<Target = [T]>,
 {
+    /// Return the inner representation of a tensor with the given
+    /// dimensions.
     fn new_inner(dims: &[u64]) -> Self;
 
     /// Wraps a TF_Tensor. Returns None if types don't match.
     unsafe fn from_tf_tensor(tensor: *mut tf::TF_Tensor) -> Option<Self>;
 
+    /// Return a mutable pointer to the C tensor.
     fn as_mut_ptr(&self, dims: &Vec<u64>) -> Result<*mut tf::TF_Tensor>;
 }
 


### PR DESCRIPTION
We would like to use a Tensorflow model in a multi-threaded server application. This should not be a problem, since Tensorflow is thread-safe (except for some session operations). However, the Rust compiler cannot derive `Send`/`Sync`. In most cases this is caused by the use of raw pointers and easy to solve by explicitly implementing these traits.

One exception is the Tensor data structure, since it uses `Cell` interior mutability for (lazily) unpacking tensors for types where the Rust and C representations are not identical.

I first considered replacing these cells by `RwLock` or `Mutex`. However, this would pollute the interface with lock guards.

Instead, I opted for another approach, implementing two different data structures:

1. `TensorDataCRepr` for types with identical C/Rust representations.. This data structure does not use interior mutability.
2. `TensorDataNoCRepr` for types with different C/Rust representations. This continues to use interior mutability.

The `Tensor` struct then uses one of these data structures based on the type parameter. In this approach the interface of `Tensor` does not change at all.

`TensorDataCRepr` is then marked as `Send`/`Sync` such that Tensors of C-compatiblity types can be used across threads.