### PR TITLE
Implement Send + Sync for GraphImpl/Operation.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -35,6 +35,9 @@ struct GraphImpl {
     inner: *mut tf::TF_Graph,
 }
 
+unsafe impl Send for GraphImpl {}
+unsafe impl Sync for GraphImpl {}
+
 impl Drop for GraphImpl {
     /// Graph will be deleted once no more Sessions are referencing it.
     fn drop(&mut self) {
@@ -531,6 +534,9 @@ pub struct Operation {
     inner: *mut tf::TF_Operation,
     gimpl: Arc<GraphImpl>,
 }
+
+unsafe impl Send for Operation {}
+unsafe impl Sync for Operation {}
 
 impl Operation {
     /// Returns the name of the operation.


### PR DESCRIPTION
According to the Tensorflow C API documentation:

    Graphs may be shared between sessions. Graphs are thread-safe when
    used as directed below.

Which presumably means when you use the C API as intended --- the C API uses a mutex to control graph access/modification.

With this change, it is possible to share a graph between sessions in different threads.