### PR TITLE
Windows: Look for existing *.dll, not *.lib

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -67,7 +67,7 @@ fn check_windows_lib() -> bool {
 
 #[cfg(target_env = "msvc")]
 fn check_windows_lib() -> bool {
-    let windows_lib: &str = &format!("{}.lib", LIBRARY);
+    let windows_lib: &str = &format!("{}.dll", LIBRARY);
     if let Ok(path) = env::var("PATH") {
         for p in path.split(";") {
             let path = Path::new(p).join(windows_lib);


### PR DESCRIPTION
On windows, build script looks for existing library among in PATH.
And then instructs linker to link with it using `dylib` which is for dynamic libraries.

But `*.lib` is static library, instead we should look for `*.dll` if we want to link dynamically

Related to #149 