### PR TITLE
Remove *Trait traits

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,3 @@
-use super::BufferTrait;
 use super::TensorType;
 use libc::c_void;
 use libc::size_t;
@@ -23,7 +22,7 @@ use tensorflow_sys as tf;
 /// This is basically a `Box<[T]>`, except that that type can't actually be constructed.
 /// Furthermore, `[T; N]` can't be constructed if N is not a compile-time constant.
 #[derive(Debug)]
-pub struct Buffer<T: TensorType> {
+pub(crate) struct Buffer<T: TensorType> {
     inner: *mut tf::TF_Buffer,
     owned: bool,
     phantom: PhantomData<T>,
@@ -124,22 +123,12 @@ impl<T: TensorType> Buffer<T> {
             phantom: PhantomData,
         }
     }
-}
 
-impl<T: TensorType> BufferTrait for Buffer<T> {
-    fn is_owned(&self) -> bool {
-        self.owned
-    }
-
-    fn set_owned(&mut self, owned: bool) {
-        self.owned = owned;
-    }
-
-    fn inner(&self) -> *const tf::TF_Buffer {
+    pub fn inner(&self) -> *const tf::TF_Buffer {
         self.inner
     }
 
-    fn inner_mut(&mut self) -> *mut tf::TF_Buffer {
+    pub fn inner_mut(&mut self) -> *mut tf::TF_Buffer {
         self.inner
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,10 +1,7 @@
 use super::buffer::Buffer;
 use super::AnyTensor;
-use super::BufferTrait;
 use super::Code;
 use super::DataType;
-use super::GraphTrait;
-use super::OperationTrait;
 use super::Result;
 use super::Shape;
 use super::Status;
@@ -817,14 +814,12 @@ impl Graph {
             }
         }
     }
-}
 
-impl GraphTrait for Graph {
-    fn inner(&self) -> *mut tf::TF_Graph {
+    pub(crate) fn inner(&self) -> *mut tf::TF_Graph {
         self.gimpl.inner
     }
 
-    unsafe fn from_c(inner: *mut tf::TF_Graph) -> Self {
+    pub(crate) unsafe fn from_c(inner: *mut tf::TF_Graph) -> Self {
         Graph {
             gimpl: Arc::new(GraphImpl {
                 inner,
@@ -1604,10 +1599,8 @@ impl Operation {
             Ok(buf.into())
         }
     }
-}
 
-impl OperationTrait for Operation {
-    fn inner(&self) -> *mut tf::TF_Operation {
+    pub(crate) fn inner(&self) -> *mut tf::TF_Operation {
         self.inner
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1274,30 +1274,6 @@ impl Library {
 
 ////////////////////////
 
-// TODO: Replace these with pub(crate)
-
-/// This exposes Buffer behavior without making it public.
-trait BufferTrait {
-    fn is_owned(&self) -> bool;
-    fn set_owned(&mut self, owned: bool);
-    fn inner(&self) -> *const tf::TF_Buffer;
-    fn inner_mut(&mut self) -> *mut tf::TF_Buffer;
-}
-
-/// This exposes Graph behavior without making it public.
-trait GraphTrait {
-    fn inner(&self) -> *mut tf::TF_Graph;
-    unsafe fn from_c(inner: *mut tf::TF_Graph) -> Self;
-}
-
-
-/// This exposes Operation behavior without making it public.
-trait OperationTrait {
-    fn inner(&self) -> *mut tf::TF_Operation;
-}
-
-////////////////////////
-
 /// Returns a string describing version information of the
 /// `TensorFlow` library. `TensorFlow` is using semantic versioning.
 pub fn version() -> std::result::Result<String, Utf8Error> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,11 +1,9 @@
 use super::AnyTensor;
-use super::{Buffer, BufferTrait};
+use super::Buffer;
 use super::Code;
 use super::DataType;
 use super::Graph;
-use super::GraphTrait;
 use super::Operation;
-use super::OperationTrait;
 use super::Result;
 use super::SessionOptions;
 use super::Status;

--- a/src/while_loop.rs
+++ b/src/while_loop.rs
@@ -1,5 +1,4 @@
 use super::Graph;
-use super::GraphTrait;
 use super::Output;
 use super::Result;
 use super::Status;


### PR DESCRIPTION
These were used as a workaround for crate-level visibility before pub(crate) existed.