### PR TITLE
Transparently convert Operations to Outputs

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -17,7 +17,6 @@ use std::ops;
 use std::rc::Rc;
 use super::Graph;
 use super::Operation;
-use super::Output;
 use super::Shape;
 use super::Status;
 use super::Tensor;
@@ -224,8 +223,8 @@ macro_rules! impl_bin_op {
       fn create_operation(&self, graph: &mut Graph, children: &[Operation],
           id_gen: &mut FnMut() -> String) -> Result<Operation, Status> {
         let mut nd = graph.new_operation($tf_op, &id_gen())?;
-        nd.add_input(Output {operation: children[0].clone(), index: 0});
-        nd.add_input(Output {operation: children[1].clone(), index: 0});
+        nd.add_input(children[0].clone());
+        nd.add_input(children[1].clone());
         nd.finish()
       }
 
@@ -315,14 +314,8 @@ impl<T: TensorType> ExprImpl<T> for TruncateDiv<T> {
                         id_gen: &mut FnMut() -> String)
                         -> Result<Operation, Status> {
         let mut nd = graph.new_operation("TruncateDiv", &id_gen())?;
-        nd.add_input(Output {
-                         operation: children[0].clone(),
-                         index: 0,
-                     });
-        nd.add_input(Output {
-                         operation: children[1].clone(),
-                         index: 0,
-                     });
+        nd.add_input(children[0].clone());
+        nd.add_input(children[1].clone());
         nd.finish()
     }
 
@@ -379,10 +372,7 @@ impl<T: TensorType> ExprImpl<T> for Neg<T> {
                         id_gen: &mut FnMut() -> String)
                         -> Result<Operation, Status> {
         let mut nd = graph.new_operation("Neg", &id_gen())?;
-        nd.add_input(Output {
-                         operation: children[0].clone(),
-                         index: 0,
-                     });
+        nd.add_input(children[0].clone());
         nd.finish()
     }
 
@@ -645,14 +635,8 @@ impl<T: TensorType> ExprImpl<T> for Assign<T> {
                         id_gen: &mut FnMut() -> String)
                         -> Result<Operation, Status> {
         let mut nd = graph.new_operation("Assign", &id_gen())?;
-        nd.add_input(Output {
-                         operation: children[0].clone(),
-                         index: 0,
-                     });
-        nd.add_input(Output {
-                         operation: children[1].clone(),
-                         index: 0,
-                     });
+        nd.add_input(children[0].clone());
+        nd.add_input(children[1].clone());
         nd.finish()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,10 +1492,7 @@ mod tests {
         };
         let y_op = {
             let mut nd = g.new_operation("EncodeBase64", "y").unwrap();
-            nd.add_input(Output {
-                operation: x_op.clone(),
-                index: 0,
-            });
+            nd.add_input(x_op.clone());
             nd.finish().unwrap()
         };
         let options = SessionOptions::new();

--- a/src/session.rs
+++ b/src/session.rs
@@ -428,7 +428,6 @@ mod tests {
     use super::super::DataType;
     use super::super::Graph;
     use super::super::Operation;
-    use super::super::Output;
     use super::super::SessionOptions;
     use super::super::Shape;
     use super::super::Tensor;
@@ -451,14 +450,8 @@ mod tests {
         };
         let y = {
             let mut nd = g.new_operation("Mul", "y").unwrap();
-            nd.add_input(Output {
-                             operation: two,
-                             index: 0,
-                         });
-            nd.add_input(Output {
-                             operation: x.clone(),
-                             index: 0,
-                         });
+            nd.add_input(two);
+            nd.add_input(x.clone());
             nd.finish().unwrap()
         };
         let options = SessionOptions::new();

--- a/src/while_loop.rs
+++ b/src/while_loop.rs
@@ -193,20 +193,11 @@ mod tests {
         let counter = inputs[0].clone();
         let less = {
             let mut nd = graph.new_operation("Less", "less").unwrap();
-            nd.add_input(Output {
-                operation: counter.operation.clone(),
-                index: 0,
-            });
-            nd.add_input(Output {
-                operation: ten,
-                index: 0,
-            });
+            nd.add_input(counter.operation);
+            nd.add_input(ten);
             nd.finish().unwrap()
         };
-        Ok(Output {
-            operation: less,
-            index: 0,
-        })
+        Ok(less.into())
     }
 
     fn while_body(graph: &mut Graph, inputs: &[Output]) -> Result<Vec<Output>> {
@@ -215,18 +206,10 @@ mod tests {
         let mul = {
             let mut nd = graph.new_operation("Mul", "mul").unwrap();
             nd.add_input(counter);
-            nd.add_input(Output {
-                operation: two,
-                index: 0,
-            });
+            nd.add_input(two);
             nd.finish().unwrap()
         };
-        Ok(vec![
-            Output {
-                operation: mul,
-                index: 0,
-            },
-        ])
+        Ok(vec![mul.into()])
     }
 
     #[test]
@@ -237,12 +220,7 @@ mod tests {
             &mut main_graph,
             while_cond,
             while_body,
-            &[
-                Output {
-                    operation: one.clone(),
-                    index: 0,
-                },
-            ],
+            &[one.into()],
         ).unwrap()
             .name("foo")
             .unwrap()
@@ -267,12 +245,7 @@ mod tests {
             &mut main_graph,
             while_cond,
             while_body,
-            &[
-                Output {
-                    operation: one.clone(),
-                    index: 0,
-                },
-            ],
+            &[one.clone().into()],
         ).unwrap()
             .finish()
             .unwrap();
@@ -280,12 +253,7 @@ mod tests {
             &mut main_graph,
             while_cond,
             while_body,
-            &[
-                Output {
-                    operation: one,
-                    index: 0,
-                },
-            ],
+            &[one.into()],
         ).unwrap()
             .finish()
             .unwrap();


### PR DESCRIPTION
Most of the time, an Output uses index 0, so this lets users avoid boilerplate by allowing Operations in many places where Outputs are required.