### PR TITLE
Allow Sessions to be used across threads

### DIFF
--- a/examples/addition.rs
+++ b/examples/addition.rs
@@ -51,7 +51,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut proto = Vec::new();
     File::open(filename)?.read_to_end(&mut proto)?;
     graph.import_graph_def(&proto, &ImportGraphDefOptions::new())?;
-    let mut session = Session::new(&SessionOptions::new(), &graph)?;
+    let session = Session::new(&SessionOptions::new(), &graph)?;
 
     // Run the graph.
     let mut args = SessionRunArgs::new();

--- a/examples/expressions.rs
+++ b/examples/expressions.rs
@@ -80,7 +80,7 @@ fn run() -> Result<(), Box<Error>> {
     //   (x_node, y_node)
     // };
     let options = SessionOptions::new();
-    let mut session = Session::new(&options, &g)?;
+    let session = Session::new(&options, &g)?;
 
     // Evaluate the graph.
     let mut x = <Tensor<f32>>::new(&[2]);

--- a/examples/regression.rs
+++ b/examples/regression.rs
@@ -60,7 +60,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut proto = Vec::new();
     File::open(filename)?.read_to_end(&mut proto)?;
     graph.import_graph_def(&proto, &ImportGraphDefOptions::new())?;
-    let mut session = Session::new(&SessionOptions::new(), &graph)?;
+    let session = Session::new(&SessionOptions::new(), &graph)?;
     let op_x = graph.operation_by_name_required("x")?;
     let op_y = graph.operation_by_name_required("y")?;
     let op_init = graph.operation_by_name_required("init")?;

--- a/examples/regression_checkpoint.rs
+++ b/examples/regression_checkpoint.rs
@@ -60,7 +60,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut proto = Vec::new();
     File::open(filename)?.read_to_end(&mut proto)?;
     graph.import_graph_def(&proto, &ImportGraphDefOptions::new())?;
-    let mut session = Session::new(&SessionOptions::new(), &graph)?;
+    let session = Session::new(&SessionOptions::new(), &graph)?;
     let op_x = graph.operation_by_name_required("x")?;
     let op_y = graph.operation_by_name_required("y")?;
     let op_init = graph.operation_by_name_required("init")?;

--- a/examples/regression_savedmodel.rs
+++ b/examples/regression_savedmodel.rs
@@ -54,10 +54,10 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     // Load the saved model exported by regression_savedmodel.py.
     let mut graph = Graph::new();
-    let mut session = Session::from_saved_model(&SessionOptions::new(), 
-                                                &["train", "serve"],
-                                                &mut graph,
-                                                export_dir)?;
+    let session = Session::from_saved_model(&SessionOptions::new(),
+                                            &["train", "serve"],
+                                            &mut graph,
+                                            export_dir)?;
     let op_x = graph.operation_by_name_required("x")?;
     let op_y = graph.operation_by_name_required("y")?;
     let op_train = graph.operation_by_name_required("train")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1441,7 +1441,7 @@ mod tests {
       0x1a, 0x01, 0x78, 0x1a, 0x03, 0x79, 0x2f, 0x79, 0x2a, 0x07, 0x0a, 0x01, 0x54,
       0x12, 0x02, 0x30, 0x01
     ];
-        let (mut session, mut graph) = create_session();
+        let (session, mut graph) = create_session();
         let opts = ImportGraphDefOptions::new();
         let status = graph.import_graph_def(&graph_proto, &opts);
         assert!(status.is_ok());
@@ -1496,7 +1496,7 @@ mod tests {
             nd.finish().unwrap()
         };
         let options = SessionOptions::new();
-        let mut session = Session::new(&options, &g).unwrap();
+        let session = Session::new(&options, &g).unwrap();
         let mut x = <Tensor<String>>::new(&[2]);
         x[0] = "foo".to_string();
         x[1] = "bar".to_string();

--- a/src/while_loop.rs
+++ b/src/while_loop.rs
@@ -228,7 +228,7 @@ mod tests {
             .unwrap();
         assert_eq!(1, output.len());
         let options = SessionOptions::new();
-        let mut session = Session::new(&options, &main_graph).unwrap();
+        let session = Session::new(&options, &main_graph).unwrap();
         let mut step = SessionRunArgs::new();
         let output_token = step.request_fetch(&output[0].operation, 0);
         session.run(&mut step).unwrap();


### PR DESCRIPTION
This implements Send and Sync for Session, which allows them to be shared across threads.  It also changes Session::run to take &self rather than &mut self, which allows Sessions to be used simulaneously in multiple threads without mutexes. This puts the responsibility on the caller to avoid race conditions.

Fixes #192