### PR TITLE
Create basic ops module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ random = "0.12.2"
 [features]
 tensorflow_gpu = ["tensorflow-sys/tensorflow_gpu"]
 tensorflow_unstable = []
+# Enables the new ops module which supports building graphs with less boilerplate.
+experimental_training = []
 # This is for testing purposes; users should not use this.
 examples_system_alloc = ["tensorflow-sys/examples_system_alloc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 libc = "0.2.43"
 aligned_alloc = "0.1.3"
 num-complex = { version = "0.2.1", default-features = false }
+tensorflow-macros = { version = "0.0.1", path = "tensorflow-macros" }
 tensorflow-sys = { version = "0.16.0", path = "tensorflow-sys" }
 byteorder = "1.2.7"
 crc = "1.8.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,11 @@ use crate::buffer::Buffer;
 mod graph;
 pub use crate::graph::*;
 
+#[cfg(feature = "experimental_training")]
+mod scope;
+#[cfg(feature = "experimental_training")]
+pub use crate::scope::*;
+
 mod session;
 pub use crate::session::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,9 @@ pub mod expr;
 
 pub mod io;
 
+#[cfg(feature = "experimental_training")]
+pub mod ops;
+
 ////////////////////////
 
 c_enum!("Error values that can be returned.", TF_Code, Code {
@@ -370,6 +373,12 @@ c_enum!("Type of a single tensor element.", TF_DataType, DataType {
   /// 64-bit unsigned integer.
   value UInt64 = 23,
 });
+
+impl Default for DataType {
+    fn default() -> DataType {
+        DataType::Float
+    }
+}
 
 ////////////////////////
 
@@ -1368,7 +1377,7 @@ pub fn get_registered_kernels_for_op(name: &str) -> Result<Vec<u8>> {
 
 /// A Shape is the shape of a tensor.  A Shape may be an unknown rank, or it may
 /// have a known rank with each dimension being known or unknown.
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Hash, Clone)]
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Default)]
 pub struct Shape(Option<Vec<Option<i64>>>);
 
 impl Shape {
@@ -1589,7 +1598,7 @@ mod tests {
     #[test]
     fn tensor_eq() {
         let a = Tensor::<i32>::new(&[3]).with_values(&[1, 2, 3]).unwrap();
-        let b = Tensor::<i32>::new(&[3]).with_values(&[1, 2, 3]).unwrap();
+        let b = Tensor::<i32>::from(&[1, 2, 3][..]);
         let c = Tensor::<i32>::new(&[3]).with_values(&[1, 2, 4]).unwrap();
         let d = Tensor::<i32>::new(&[3, 1]).with_values(&[1, 2, 3]).unwrap();
         assert_eq!(a, b);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,29 @@
+//! This module exposes functions for building standard operations.
+//!
+//! This module currently requires the `experimental_training` feature.
+//!
+//! Each operation has a struct which can be used as a builder and allows
+//! setting optional attributes:
+//!
+//! ```ignore
+//! MatMul::new().transpose_a(true).build(&mut scope, a, b)?;
+//! ```
+//!
+//! and a function which is shorter when no attributes need to be set:
+//!
+//! ```ignore
+//! mat_mul(&mut scope, a, b)
+//! ```
+
+use tensorflow_macros::define_op;
+
+mod array_ops;
+pub use array_ops::*;
+
+mod math_ops;
+pub use math_ops::*;
+
+mod random_ops;
+pub use random_ops::*;
+
+define_op!(no_op, NoOp, "NoOp");

--- a/src/ops/array_ops.rs
+++ b/src/ops/array_ops.rs
@@ -1,0 +1,3 @@
+use tensorflow_macros::define_op;
+
+define_op!(zeros_like, ZerosLike, "ZerosLike", args { x });

--- a/src/ops/math_ops.rs
+++ b/src/ops/math_ops.rs
@@ -1,0 +1,52 @@
+use crate::Operation;
+use crate::Result;
+use crate::Scope;
+use crate::Tensor;
+use crate::TensorType;
+use tensorflow_macros::define_op;
+
+define_op!(add, Add, "Add", args { a, b });
+
+/// Creates a constant.
+///
+/// The value can be anything convertible to a tensor, so possibilities include:
+///
+/// ```
+/// # use std::error::Error;
+/// # use tensorflow::Scope;
+/// # use tensorflow::Tensor;
+/// # use tensorflow::ops::constant;
+/// # let mut scope = Scope::new_root_scope();
+/// let a = constant(&mut scope, 1.0f32)?;
+/// let b = constant(&mut scope, &[1.0f32, 2.0][..])?;
+/// let c = constant(&mut scope, Tensor::new(&[2, 2]).with_values(&[0f32, 1.0, 2.0, 3.0])?)?;
+/// # Ok::<(), Box<Error>>(())
+/// ```
+///
+/// Note that e.g. `&[1, 2][..]` is used instead of `&[1, 2]`.  This forces the
+/// compiler to treat the value as a slice rather than a reference to a
+/// fixed-size array.  This is necessary because `Into<Tensor>` is implemented
+/// for slices but not arrays, and the compiler doesn't automatically fall back
+/// to treating the array reference as a slice.
+pub fn constant<T: TensorType, TT: Into<Tensor<T>>>(
+    scope: &mut Scope,
+    value: TT,
+) -> Result<Operation> {
+    let name = scope.get_unique_name_for_op("Const");
+    let mut graph = scope.graph_mut();
+    let mut c = graph.new_operation("Const", &name)?;
+    c.set_attr_tensor("value", value.into())?;
+    c.set_attr_type("dtype", T::data_type())?;
+    c.finish()
+}
+
+define_op!(mat_mul, MatMul, "MatMul", args {a, b}, attrs {
+    transpose_a: bool => "transpose_a",
+    transpose_b: bool => "transpose_b",
+});
+
+define_op!(multiply, Multiply, "Mul", args { a, b });
+
+define_op!(subtract, Subtract, "Sub", args { a, b });
+
+define_op!(tanh, Tanh, "Tanh", args { x });

--- a/src/ops/random_ops.rs
+++ b/src/ops/random_ops.rs
@@ -1,0 +1,8 @@
+use crate::DataType;
+use tensorflow_macros::define_op;
+
+define_op!(random_normal, RandomNormal, "RandomStandardNormal", args{x}, attrs {
+    dtype: DataType => "dtype",
+    seed?: i64 => "seed",
+    seed2?: i64 => "seed2",
+});

--- a/src/ops/state_ops.rs
+++ b/src/ops/state_ops.rs
@@ -1,0 +1,16 @@
+use crate::DataType;
+use crate::Operation;
+use crate::Output;
+use crate::Result;
+use crate::Scope;
+use crate::Shape;
+use crate::Tensor;
+use crate::TensorType;
+use tensorflow_macros::define_op;
+
+define_op!(assign, Assign, "Assign", args {a, b});
+
+define_op!(placeholder, Placeholder, "Placeholder", attrs {
+    data_type: DataType => "dtype",
+    shape: Shape => "shape",
+});

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,0 +1,228 @@
+use crate::Graph;
+use crate::Operation;
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::rc::Rc;
+
+/// Joins left and right using the separator.  If either left or right is the
+/// empty string, the separator is left out.
+fn join(sep: &str, left: &str, right: &str) -> String {
+    match (left, right) {
+        ("", _) => right.to_string(),
+        (_, "") => left.to_string(),
+        _ => format!("{}{}{}", left, sep, right),
+    }
+}
+
+// TODO: Include other with_* functions
+/// A `Scope` object represents a set of related TensorFlow ops that have the
+/// same properties such as a common name prefix.
+///
+/// This type currently requires the `experimental_training` feature.
+///
+/// A Scope object is a container for TensorFlow Op properties. Op constructors
+/// get a Scope object as a mandatory first argument and the constructed op
+/// acquires the properties in the object.
+///
+// TODO: Fix this example
+// A simple example:
+//
+// ```ignore
+// let root = Scope::new_root_scope();
+// let c1 = Const(&root, { {1, 1} });
+// let m = MatMul(&root, c1, { {41}, {1} });
+// ```
+//
+/// # Scope hierarchy
+///
+/// The Scope class provides various `with_*` functions that create a new scope.
+/// The new scope typically has one property changed while other properties are
+/// inherited from the parent scope.
+/// `new_sub_scope(name)` method appends `name` to the prefix of names for ops
+/// created within the scope, and `with_op_name()` changes the suffix which
+/// otherwise defaults to the type of the op.
+///
+// TODO: Fix this example
+// Name examples:
+//
+// ```ignore
+// let root = Scope::new_root_scope();
+// let linear = root.new_sub_scope("linear");
+// // W will be named "linear/W"
+// let W = Variable(&linear.with_op_name("W"),
+//                   {2, 2}, DataType::Float);
+// // b will be named "linear/b_3"
+// let idx = 3;
+// let b = Variable(&linear.with_op_name("b_", idx),
+//                   {2}, DataType::Float);
+// let x = Const(&linear, {...});  // name: "linear/Const"
+// let m = MatMul(&linear, x, W);  // name: "linear/MatMul"
+// let r = BiasAdd(&linear, m, b); // name: "linear/BiasAdd"
+// ```
+//
+/// # Scope lifetime
+///
+/// A new scope is created by calling `Scope::new_root_scope`. This creates some
+/// resources that are shared by all the child scopes that inherit from this
+/// scope, directly or transitively. For instance, a new scope creates a new
+/// Graph object to which operations are added when the new scope or its
+/// children are used by an Op constructor.
+#[derive(Debug)]
+pub struct Scope {
+    graph: Rc<RefCell<Graph>>,
+    name: String,
+    children_names: Rc<RefCell<HashSet<String>>>,
+    op_name: String,
+    op_names: Rc<RefCell<HashMap<String, i32>>>,
+}
+
+impl Scope {
+    /// Return a new scope.
+    /// This creates a new graph and all operations constructed in this graph
+    /// should use the returned object as the "root" scope.
+    pub fn new_root_scope() -> Scope {
+        Scope {
+            graph: Rc::new(RefCell::new(Graph::new())),
+            name: "".to_string(),
+            children_names: Rc::new(RefCell::new(HashSet::new())),
+            op_name: "".to_string(),
+            op_names: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    /// Adds a suffix if necessary to create a unique subscope name.
+    fn uniquify(&self, name: &str) -> String {
+        let refcell: &RefCell<_> = self.children_names.borrow();
+        let mut set = refcell.borrow_mut();
+        if set.insert(name.to_string()) {
+            return name.to_string();
+        }
+        let mut i = 1;
+        loop {
+            let unique_name = format!("{}_{}", &name, i);
+            if set.insert(unique_name.clone()) {
+                return unique_name;
+            }
+            i += 1;
+        }
+    }
+
+    /// Return a new scope. Ops created with this scope will have
+    /// `name/child_scope_name` as the prefix. The actual name will be unique
+    /// in the current scope. All other properties are inherited from the current
+    /// scope. If `child_scope_name` is empty, the `/` is elided.
+    pub fn new_sub_scope(&self, name: &str) -> Scope {
+        let self_name: &str = &self.name;
+        let (new_name, copy_names) = match (self_name, name) {
+            (_, "") => (self.name.clone(), true),
+            ("", _) => (self.uniquify(name), false),
+            _ => (format!("{}/{}", self.name, self.uniquify(name)), false),
+        };
+        Scope {
+            graph: self.graph.clone(),
+            name: new_name,
+            children_names: Rc::new(RefCell::new(HashSet::new())),
+            op_name: self.op_name.clone(),
+            op_names: if copy_names {
+                self.op_names.clone()
+            } else {
+                Rc::new(RefCell::new(HashMap::new()))
+            },
+        }
+    }
+
+    /// Return a new scope. All ops created within the returned scope will have
+    /// names of the form `scope_name/name[_suffix]`
+    pub fn with_op_name(&self, name: &str) -> Scope {
+        Scope {
+            graph: self.graph.clone(),
+            name: self.name.clone(),
+            children_names: self.children_names.clone(),
+            op_name: name.to_string(),
+            op_names: self.op_names.clone(),
+        }
+    }
+
+    /// Return a unique name, using default_name if an op name has not been
+    /// specified.
+    pub fn get_unique_name_for_op(&self, default_name: &str) -> String {
+        let name = if self.op_name == "" {
+            default_name
+        } else {
+            &self.op_name
+        };
+        let map: &RefCell<_> = self.op_names.borrow();
+        let mut map = map.borrow_mut();
+        let mut name_string = name.to_string();
+        loop {
+            match map.entry(name_string.clone()) {
+                Entry::Vacant(e) => {
+                    e.insert(0);
+                    return join("/", &self.name, &name_string);
+                }
+                Entry::Occupied(mut e) => {
+                    *e.get_mut() += 1;
+                    name_string = format!("{}_{}", name, *e.get());
+                }
+            }
+        }
+    }
+
+    /// Returns the graph being built by the scope.
+    pub fn graph(&self) -> impl Deref<Target = Graph> + '_ {
+        let r: &RefCell<Graph> = self.graph.borrow();
+        r.borrow()
+    }
+
+    /// Returns the graph being built by the scope.
+    pub fn graph_mut(&mut self) -> impl DerefMut<Target = Graph> + '_ {
+        let r: &RefCell<Graph> = self.graph.borrow();
+        r.borrow_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DataType;
+
+    #[test]
+    fn smoke() {
+        let mut scope = Scope::new_root_scope();
+        let mut graph = scope.graph_mut();
+        let mut c = graph.new_operation("Const", "Const").unwrap();
+        c.set_attr_tensor("value", 3.0f32.into()).unwrap();
+        c.set_attr_type("dtype", DataType::Float).unwrap();
+        c.finish().unwrap();
+    }
+
+    #[test]
+    fn uniquification() {
+        let scope = Scope::new_root_scope();
+        assert_eq!(&scope.new_sub_scope("foo").name, "foo");
+        assert_eq!(&scope.new_sub_scope("foo").name, "foo_1");
+        let foo_1 = scope.new_sub_scope("foo");
+        assert_eq!(&foo_1.name, "foo_2");
+        assert_eq!(&foo_1.new_sub_scope("bar").name, "foo_2/bar");
+        assert_eq!(&foo_1.new_sub_scope("bar").name, "foo_2/bar_1");
+        assert_eq!(&foo_1.new_sub_scope("bar").name, "foo_2/bar_2");
+    }
+
+    #[test]
+    fn get_unique_name_for_op() {
+        let scope = Scope::new_root_scope();
+        assert_eq!(scope.get_unique_name_for_op("Add"), "Add");
+        assert_eq!(scope.get_unique_name_for_op("Add"), "Add_1");
+        let foo = scope.new_sub_scope("foo");
+        assert_eq!(foo.get_unique_name_for_op("Add"), "foo/Add");
+        assert_eq!(foo.get_unique_name_for_op("Add"), "foo/Add_1");
+        let bar = foo.with_op_name("bar");
+        assert_eq!(bar.get_unique_name_for_op("Add"), "foo/bar");
+        assert_eq!(bar.get_unique_name_for_op("Add"), "foo/bar_1");
+    }
+}

--- a/tensorflow-macros/Cargo.toml
+++ b/tensorflow-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tensorflow-macros"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = [
+  "Adam Crume <acrume@google.com>",
+]
+description = "The package provides macros for internal usage in TensorFlow."
+documentation = "https://tensorflow.github.io/rust"
+homepage = "https://github.com/tensorflow/rust"
+repository = "https://github.com/tensorflow/rust"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6"
+syn = { version = "0.15.36", features = ["extra-traits"] }
+proc-macro2 = "0.4"

--- a/tensorflow-macros/src/lib.rs
+++ b/tensorflow-macros/src/lib.rs
@@ -1,0 +1,376 @@
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Literal;
+use proc_macro2::Span;
+use quote::quote;
+use quote::ToTokens;
+use syn::braced;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
+use syn::parse_macro_input;
+use syn::punctuated::Punctuated;
+use syn::Error;
+use syn::Ident;
+use syn::LitStr;
+use syn::Result;
+use syn::Token;
+use syn::Type;
+
+#[derive(Clone)]
+struct Arg {
+    name: Ident,
+}
+
+impl Parse for Arg {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let name = input.parse()?;
+        Ok(Arg { name })
+    }
+}
+
+struct Args {
+    args: Punctuated<Arg, Token![,]>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let list;
+        braced!(list in input);
+        Ok(Args {
+            args: list.parse_terminated(Arg::parse)?,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct Attr {
+    optional: bool,
+    rust_name: Ident,
+    attr_type: Type,
+    c_name: LitStr,
+}
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let rust_name = input.parse()?;
+        let mut optional = false;
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Token![?]) {
+            input.parse::<Token![?]>()?;
+            optional = true;
+        }
+        input.parse::<Token![:]>()?;
+        let attr_type = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let c_name = input.parse()?;
+        Ok(Attr {
+            optional,
+            rust_name,
+            attr_type,
+            c_name,
+        })
+    }
+}
+
+struct Attrs {
+    attrs: Punctuated<Attr, Token![,]>,
+}
+
+impl Parse for Attrs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let list;
+        braced!(list in input);
+        Ok(Attrs {
+            attrs: list.parse_terminated(Attr::parse)?,
+        })
+    }
+}
+
+struct DefineOpInput {
+    fn_name: Ident,
+    name: Ident,
+    op_name: LitStr,
+    args: Vec<Arg>,
+    attrs: Vec<Attr>,
+}
+
+impl Parse for DefineOpInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let fn_name = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let name = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let op_name = input.parse()?;
+        let mut args = Vec::new();
+        let mut attrs = Vec::new();
+        loop {
+            let lookahead = input.lookahead1();
+            if !lookahead.peek(Token![,]) {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+            let ident: Ident = input.parse()?;
+            if ident.to_string() == "args" {
+                let new_args: Args = input.parse()?;
+                args.extend(new_args.args);
+            } else if ident.to_string() == "attrs" {
+                let new_attrs: Attrs = input.parse()?;
+                attrs.extend(new_attrs.attrs);
+            } else {
+                return Err(Error::new(Span::call_site(), "expected `attrs` or `args`"));
+            }
+        }
+        Ok(DefineOpInput {
+            fn_name,
+            name,
+            op_name,
+            args,
+            attrs,
+        })
+    }
+}
+
+struct AttrDefs<'a>(&'a [Attr]);
+
+impl<'a> ToTokens for AttrDefs<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for attr in self.0 {
+            let rust_name = &attr.rust_name;
+            let attr_type = &attr.attr_type;
+            if attr.optional {
+                tokens.extend(quote! { #rust_name: ::std::option::Option<#attr_type>, });
+            } else {
+                tokens.extend(quote! { #rust_name: #attr_type, });
+            }
+        }
+    }
+}
+
+struct AttrSetters<'a>(&'a [Attr]);
+
+impl<'a> ToTokens for AttrSetters<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for attr in self.0 {
+            let comment =
+                Literal::string(&format!("Sets the `{}` attribute.", attr.c_name.value()));
+            let rust_name = &attr.rust_name;
+            let attr_type = &attr.attr_type;
+            let mut needs_into = false;
+            let mut arg_type = attr_type.clone();
+            if attr_type == &syn::parse_str::<Type>("String").unwrap() {
+                needs_into = true;
+                // TODO: don't use parse
+                arg_type = syn::parse_str::<Type>("&str").unwrap()
+            };
+            let mut value = quote! { value };
+            if needs_into {
+                value = quote! { <#arg_type as ::std::convert::Into<#attr_type>>::into(#value) };
+            }
+            if attr.optional {
+                value = quote! { ::std::option::Option::Some(#value) };
+            }
+            tokens.extend(quote! {
+                #[doc = #comment]
+                pub fn #rust_name(mut self, value: #arg_type) -> Self {
+                    self.#rust_name = #value;
+                    self
+                }
+            });
+        }
+    }
+}
+
+struct BuildFnGenerics {
+    arg_count: usize,
+}
+
+impl ToTokens for BuildFnGenerics {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        if self.arg_count == 0 {
+            return;
+        }
+        tokens.extend(quote! {<});
+        for i in 0..self.arg_count {
+            if i > 0 {
+                tokens.extend(quote! {,});
+            }
+            let arg = Ident::new(&format!("O{}", i + 1), Span::call_site());
+            tokens.extend(quote! {#arg: ::std::convert::Into<crate::Output>});
+        }
+        tokens.extend(quote! {>});
+    }
+}
+
+struct BuildFnArgs<'a> {
+    args: &'a [Arg],
+}
+
+impl<'a> ToTokens for BuildFnArgs<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for (i, arg) in self.args.iter().enumerate() {
+            let arg_name = &arg.name;
+            let arg_type = Ident::new(&format!("O{}", i + 1), Span::call_site());
+            tokens.extend(quote! {, #arg_name: #arg_type});
+        }
+    }
+}
+
+struct SetAttr<'a> {
+    attr: &'a Attr,
+}
+
+impl<'a> ToTokens for SetAttr<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let c_name = &self.attr.c_name;
+        let rust_name = &self.attr.rust_name;
+        let setter = |value| match self
+            .attr
+            .attr_type
+            .clone()
+            .into_token_stream()
+            .to_string()
+            .as_str()
+        {
+            "String" => quote! { nd.set_attr_string(#c_name, &#value)?; },
+            "DataType" => quote! { nd.set_attr_type(#c_name, #value)?; },
+            "bool" => quote! { nd.set_attr_bool(#c_name, #value)?; },
+            "i64" => quote! { nd.set_attr_int(#c_name, #value)?; },
+            ty => panic!(
+                "Unrecognized attribute type for {}: {}",
+                self.attr.rust_name, ty
+            ),
+        };
+        tokens.extend(if self.attr.optional {
+            let set = setter(quote! { *value });
+            quote! {
+                if let Some(value) = &self.#rust_name {
+                    #set
+                }
+            }
+        } else {
+            setter(quote! { self.#rust_name })
+        });
+    }
+}
+
+struct BuildFn<'a> {
+    op_name: &'a LitStr,
+    args: &'a [Arg],
+    attrs: &'a [Attr],
+}
+
+impl<'a> ToTokens for BuildFn<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let op_name = &self.op_name;
+        let build_fn_generics = BuildFnGenerics {
+            arg_count: self.args.len(),
+        };
+        let build_fn_args = BuildFnArgs { args: &self.args };
+        let arg_names = self.args.iter().map(|arg| &arg.name);
+        let set_attrs = self.attrs.iter().map(|attr| SetAttr { attr });
+        tokens.extend(quote! {
+            #[doc = "Builds the `"]
+            #[doc = #op_name]
+            #[doc = "` operation."]
+            pub fn build#build_fn_generics(&self, scope: &mut crate::Scope #build_fn_args) -> crate::Result<crate::Operation> {
+                let name = scope.get_unique_name_for_op(#op_name);
+                let mut graph = scope.graph_mut();
+                let mut nd = graph.new_operation(#op_name, &name)?;
+                #(
+                    nd.add_input(#arg_names);
+                )*
+                for op in &self.control_inputs {
+                    nd.add_control_input(op);
+                }
+                #(#set_attrs)*
+                nd.finish()
+            }
+        });
+    }
+}
+
+struct ShortFn<'a> {
+    name: &'a Ident,
+    fn_name: &'a Ident,
+    args: &'a [Arg],
+}
+
+impl<'a> ToTokens for ShortFn<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let name = &self.name;
+        let fn_name = &self.fn_name;
+        let build_fn_generics = BuildFnGenerics {
+            arg_count: self.args.len(),
+        };
+        let build_fn_args = BuildFnArgs { args: &self.args };
+        let arg_names = self.args.iter().map(|arg| &arg.name);
+        let mut docs = format!("Shorthand for `{}::new().build(scope", name);
+        for arg in self.args {
+            docs.push_str(", ");
+            docs.push_str(&arg.name.to_string());
+        }
+        docs.push_str(")`.");
+        tokens.extend(quote! {
+            #[doc = #docs]
+            pub fn #fn_name#build_fn_generics(scope: &mut crate::Scope #build_fn_args) -> crate::Result<crate::Operation> {
+                #name::new().build(scope #(, #arg_names)*)
+            }
+        });
+    }
+}
+
+#[proc_macro]
+pub fn define_op(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DefineOpInput);
+    let fn_name = input.fn_name;
+    let name = input.name;
+    let op_name = input.op_name;
+    let name_str = name.to_string();
+    let name_str_plus_period = name_str + ".";
+    let attr_defs = AttrDefs(&input.attrs);
+    let attr_setters = AttrSetters(&input.attrs);
+    let build_fn = BuildFn {
+        op_name: &op_name,
+        args: &input.args,
+        attrs: &input.attrs,
+    };
+    let short_fn = ShortFn {
+        name: &name,
+        fn_name: &fn_name,
+        args: &input.args,
+    };
+    let stream = quote! {
+        #[doc = "Builder for the `"]
+        #[doc = #op_name]
+        #[doc = "` operation."]
+        #[derive(Debug,Default)]
+        pub struct #name {
+            #attr_defs
+            control_inputs: Vec<crate::Operation>,
+        }
+
+        impl #name {
+            #[doc = "Creates a new"]
+            #[doc = #name_str_plus_period]
+            pub fn new() -> Self {
+                Self::default()
+            }
+
+            #attr_setters
+
+            /// Adds a control input.
+            pub fn add_control_input(mut self, op: crate::Operation) -> Self {
+                self.control_inputs.push(op);
+                self
+            }
+
+            #build_fn
+        }
+
+        #short_fn
+    };
+    stream.into()
+}

--- a/test-all
+++ b/test-all
@@ -38,10 +38,13 @@ if [[ "${version_tensorflow_sys_crate}" != "${version_tensorflow_sys_readme}" ]]
 fi
 
 cargo fmt --all -- --check
+cargo test -vv -j 2
 cargo test -vv -j 2 --features tensorflow_unstable
+cargo test -vv -j 2 --features experimental_training
+cargo test -vv -j 2 --features tensorflow_unstable,experimental_training
 cargo run --example regression
 cargo run --features tensorflow_unstable --example expressions
-cargo doc -vv --features tensorflow_unstable
+cargo doc -vv --features tensorflow_unstable,experimental_training
 # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
 (cd tensorflow-sys && cargo run --example multiplication)
 (cd tensorflow-sys && cargo doc -vv)


### PR DESCRIPTION
This creates an `ops` module with a few basic operations implemented.  This is the first pull request in a sequence intended to support defining and training models entirely in Rust (no Python necessary).