### PR TITLE
set rustc-link-lib/search for tensorflow lib found via pkg_config

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -43,7 +43,13 @@ fn main() {
         return;
     }
 
-    if pkg_config::find_library(LIBRARY).is_ok() {
+    if let Ok(library) = pkg_config::find_library(LIBRARY) {
+        for lib in &library.libs {
+            println!("cargo:rustc-link-lib=dylib={}", lib);
+        }
+        for path in &library.link_paths {
+            println!("cargo:rustc-link-search=native={}", path.display());
+        }
         log!("Returning early because {} was already found", LIBRARY);
         return;
     }


### PR DESCRIPTION
Currently, if a Tensorflow library is installed in a non-system folder (e.g., /opt/tensorflow/lib) but still discoverable via pkg_config then dependent crates will fail to link at compile time.

This sets rustc-link-lib and rustc-link-search values for the library discovered by pkg_config.