### PR TITLE
Revert "set rustc-link-lib/search for tensorflow lib found via pkg_config"

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -43,13 +43,7 @@ fn main() {
         return;
     }
 
-    if let Ok(library) = pkg_config::find_library(LIBRARY) {
-        for lib in &library.libs {
-            println!("cargo:rustc-link-lib=dylib={}", lib);
-        }
-        for path in &library.link_paths {
-            println!("cargo:rustc-link-search=native={}", path.display());
-        }
+    if pkg_config::find_library(LIBRARY).is_ok() {
         log!("Returning early because {} was already found", LIBRARY);
         return;
     }


### PR DESCRIPTION
Reverts tensorflow/rust#217

On closer inspection, `find_library` does print these by default. I was hitting an unrelated bug with pkg-config itself. Apologies for the confusion.