### PR TITLE
Rename the tensorflow-macros crate to tensorflow-internal-macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 libc = "0.2.43"
 aligned_alloc = "0.1.3"
 num-complex = { version = "0.2.1", default-features = false }
-tensorflow-macros = { version = "0.0.1", path = "tensorflow-macros" }
+tensorflow-internal-macros = { version = "=0.0.1", path = "tensorflow-internal-macros" }
 tensorflow-sys = { version = "0.17.0", path = "tensorflow-sys" }
 byteorder = "1.2.7"
 crc = "1.8.1"

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -15,7 +15,7 @@
 //! mat_mul(a, b, &mut scope)
 //! ```
 
-use tensorflow_macros::define_op;
+use tensorflow_internal_macros::define_op;
 
 mod array_ops;
 pub use array_ops::*;

--- a/src/ops/array_ops.rs
+++ b/src/ops/array_ops.rs
@@ -1,3 +1,3 @@
-use tensorflow_macros::define_op;
+use tensorflow_internal_macros::define_op;
 
 define_op!(zeros_like, ZerosLike, "ZerosLike", args { x });

--- a/src/ops/math_ops.rs
+++ b/src/ops/math_ops.rs
@@ -4,7 +4,7 @@ use crate::Result;
 use crate::Scope;
 use crate::Tensor;
 use crate::TensorType;
-use tensorflow_macros::define_op;
+use tensorflow_internal_macros::define_op;
 
 define_op!(add, Add, "Add", args { a, b });
 

--- a/src/ops/random_ops.rs
+++ b/src/ops/random_ops.rs
@@ -1,5 +1,5 @@
 use crate::DataType;
-use tensorflow_macros::define_op;
+use tensorflow_internal_macros::define_op;
 
 define_op!(random_normal, RandomNormal, "RandomStandardNormal", args{x}, attrs {
     dtype: DataType => "dtype",

--- a/src/ops/state_ops.rs
+++ b/src/ops/state_ops.rs
@@ -6,7 +6,7 @@ use crate::Scope;
 use crate::Shape;
 use crate::Tensor;
 use crate::TensorType;
-use tensorflow_macros::define_op;
+use tensorflow_internal_macros::define_op;
 
 define_op!(assign, Assign, "Assign", args { a, b });
 

--- a/tensorflow-internal-macros/Cargo.toml
+++ b/tensorflow-internal-macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "tensorflow-macros"
+name = "tensorflow-internal-macros"
 version = "0.0.1"
 license = "Apache-2.0"
 authors = [
   "Adam Crume <acrume@google.com>",
 ]
-description = "The package provides macros for internal usage in TensorFlow."
+description = "The package provides macros for internal usage in TensorFlow. No backwards compatibility guarantees are made."
 documentation = "https://tensorflow.github.io/rust"
 homepage = "https://github.com/tensorflow/rust"
 repository = "https://github.com/tensorflow/rust"

--- a/tensorflow-internal-macros/src/lib.rs
+++ b/tensorflow-internal-macros/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "128"]
+//! The package provides macros for internal usage in TensorFlow. No backwards
+//! compatibility guarantees are made.
 
 extern crate proc_macro;
 


### PR DESCRIPTION
I mistakenly thought that this didn't need to be published to crates.io, but it does, so this makes it clear that it is not intended to be used by others.