### PR TITLE
Use `std::alloc` instead of `aligned_alloc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.62"
-aligned_alloc = "0.1.3"
 num-complex = { version = "0.2.3", default-features = false }
 tensorflow-internal-macros = { version = "=0.0.1", path = "tensorflow-internal-macros" }
 tensorflow-sys = { version = "0.17.0", path = "tensorflow-sys" }


### PR DESCRIPTION
`aligned_alloc` is my most downloaded crate, only because the Tensorflow bindings are using it. They should not, since the crate is slow, wasteful, and buggy. Fortunately, `std::alloc` now has enough stable API surface to replace `aligned_alloc` here.