### PR TITLE
RecordReader for TFRecords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ travis-ci/travis_rsa
 **/*.iml
 .idea
 test_resources/io/actual.tfrecord
+test_resources/io/roundtrip.tfrecord

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,12 +1,19 @@
-//! A module for writing TFRecords, Tensorflow's preferred on-disk data format.
+//! A module for reading and writing TFRecords, Tensorflow's preferred on-disk data format.
 //!
-//! See the [tensorflow docs](https://www.tensorflow.org/api_guides/python/python_io#tfrecords-format-details) for details of this format.
+//! See the [tensorflow docs](https://www.tensorflow.org/api_guides/python/python_io#tfrecords-format-details)
+//! for details of this format.
+use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use self::byteorder::WriteBytesExt;
-use byteorder;
 use crc::crc32;
-use std::io;
-use std::io::Write;
+use std::{
+    error::Error,
+    fmt, io,
+    io::{Read, Seek, SeekFrom, Write},
+};
+
+fn mask_crc(crc: u32) -> u32 {
+    ((crc >> 15) | (crc << 17)).wrapping_add(0xa282ead8u32)
+}
 
 /// A type for writing bytes in the TFRecords format.
 #[derive(Debug)]
@@ -32,20 +39,22 @@ where
         uint32 masked_crc32_of_length
         byte   data[length]
         uint32 masked_crc32_of_data
-        and the records are concatenated together to produce the file. CRCs are described here [1], and the mask of a CRC is
-        [1] https://en.wikipedia.org/wiki/Cyclic_redundancy_check
+        and the records are concatenated together to produce the file. CRCs are described here [1],
+        and the mask of a CRC is :
         masked_crc = ((crc >> 15) | (crc << 17)) + 0xa282ead8ul
+
+        [1] https://en.wikipedia.org/wiki/Cyclic_redundancy_check
         */
         let mut len_bytes = [0u8; 8];
-        (&mut len_bytes[..]).write_u64::<byteorder::LittleEndian>(bytes.len() as u64)?;
+        (&mut len_bytes[..]).write_u64::<LittleEndian>(bytes.len() as u64)?;
 
-        let masked_len_crc32c = Self::mask(crc32::checksum_castagnoli(&len_bytes));
+        let masked_len_crc32c = mask_crc(crc32::checksum_castagnoli(&len_bytes));
         let mut len_crc32_bytes = [0u8; 4];
-        (&mut len_crc32_bytes[..]).write_u32::<byteorder::LittleEndian>(masked_len_crc32c)?;
+        (&mut len_crc32_bytes[..]).write_u32::<LittleEndian>(masked_len_crc32c)?;
 
-        let masked_bytes_crc32c = Self::mask(crc32::checksum_castagnoli(&bytes));
+        let masked_bytes_crc32c = mask_crc(crc32::checksum_castagnoli(&bytes));
         let mut bytes_crc32_bytes = [0u8; 4];
-        (&mut bytes_crc32_bytes[..]).write_u32::<byteorder::LittleEndian>(masked_bytes_crc32c)?;
+        (&mut bytes_crc32_bytes[..]).write_u32::<LittleEndian>(masked_bytes_crc32c)?;
 
         self.writer.write(&len_bytes)?;
         self.writer.write(&len_crc32_bytes)?;
@@ -53,9 +62,300 @@ where
         self.writer.write(&bytes_crc32_bytes)?;
         Ok(())
     }
+}
 
-    fn mask(crc: u32) -> u32 {
-        ((crc >> 15) | (crc << 17)).wrapping_add(0xa282ead8u32)
+#[derive(Debug)]
+/// The possible errors from a record read attempt
+pub enum RecordReadError {
+    /// This record is corrupt (failed a checksum), but we might be able to recover.
+    /// A subsequent call to read_next() might yield the next record.
+    CorruptRecord,
+
+    /// The entire file is corrupted. This is a terminal error.
+    CorruptFile,
+
+    /// There was an underlying io error. Depending on the source of the error, this may be a
+    /// a transient or permanent failure.
+    IoError {
+        /// The underlying io::Error
+        source: io::Error,
+    },
+
+    /// The supplied buffer was too short to contain the next record.
+    BufferTooShort {
+        /// The length of the record that was too long to read.
+        needed: u64,
+    },
+}
+
+impl From<io::Error> for RecordReadError {
+    fn from(from: io::Error) -> RecordReadError {
+        RecordReadError::IoError { source: from }
+    }
+}
+
+impl Error for RecordReadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RecordReadError::IoError { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RecordReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// A type for deserializing TFRecord formats
+#[derive(Debug)]
+pub struct RecordReader<R: Read + Seek> {
+    reader: R,
+}
+
+impl<R> RecordReader<R>
+where
+    R: Read + Seek,
+{
+    /// Construct a new RecordReader from an underlying Read.
+    pub fn new(reader: R) -> Self {
+        RecordReader { reader }
+    }
+
+    fn read_next_len_unchecked(&mut self) -> Result<Option<u64>, RecordReadError> {
+        match self.reader.read_u64::<LittleEndian>() {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::UnexpectedEof {
+                    Ok(None)
+                } else {
+                    Err(e.into())
+                }
+            }
+            Ok(val) => Ok(Some(val)),
+        }
+    }
+
+    fn checksum(&mut self, bytes: &[u8]) -> Result<bool, RecordReadError> {
+        let actual_bytes_crc32 = mask_crc(crc32::checksum_castagnoli(&bytes));
+        let expected_bytes_crc32 = self.reader.read_u32::<LittleEndian>()?;
+        if actual_bytes_crc32 != expected_bytes_crc32 {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+    fn read_bytes_exact_unchecked(&mut self, buf: &mut [u8]) -> Result<(), RecordReadError> {
+        self.reader.read_exact(buf)?;
+        Ok(())
+    }
+
+    /// The length of the next record. Does not checksum the length.
+    /// Use this to find out how large the byte slice needs to be to read the next record.
+    pub fn peek_next_len(&mut self) -> Result<Option<u64>, RecordReadError> {
+        let len = self.read_next_len_unchecked()?;
+        match len {
+            Some(_len) => {
+                self.reader.seek(SeekFrom::Current(-8))?;
+            }
+            _ => {}
+        }
+
+        Ok(len)
+    }
+    /// Read the next record into a byte slice.
+    /// Returns the number of bytes read, if successful.
+    /// Returns None, if it could read exactly 0 bytes (indicating EOF)
+    ///
+    /// # Examples
+    /// ```
+    /// // When we are sure of the max item size, we can just stack allocate an array to hold
+    /// use tensorflow::io::{RecordReadError, RecordReader, RecordWriter};
+    /// use std::{io::Cursor, rc::Rc};
+    /// let mut buf = Vec::new();
+    /// let mut rc = Rc::new(&mut buf);
+    /// let records = vec!["foo", "barr", "baz"];
+    /// {
+    ///     let mut writer = RecordWriter::new(Rc::get_mut(&mut rc).unwrap());
+    ///     for rec in records.iter() {
+    ///         writer.write_record(rec.as_bytes()).unwrap();
+    ///     }
+    /// }
+    /// let read = std::io::BufReader::new(Cursor::new(buf));
+    /// let mut reader = RecordReader::new(read);
+    /// let mut ary = [0u8; 4];
+    /// let mut i = 0;
+    /// loop {
+    ///     let next = reader.read_next(&mut ary);
+    ///     match next {
+    ///         Ok(res) => match res {
+    ///             Some(len) => assert_eq!(&ary[0..len], records[i].as_bytes()),
+    ///             None => break,
+    ///         },
+    ///         Err(RecordReadError::CorruptFile) | Err(RecordReadError::IoError { .. }) => {
+    ///             break;
+    ///         }
+    ///         _ => {}
+    ///     }
+    ///     i += 1;
+    /// }
+    /// ```
+    /// When we may need to dynamically resize our buffer, use this peek_next_len()
+    /// ```
+    /// use tensorflow::io::{RecordReadError, RecordReader, RecordWriter};
+    /// use std::{io::Cursor, rc::Rc};
+    /// let mut buf = Vec::new();
+    /// let mut rc = Rc::new(&mut buf);
+    /// let records = vec!["foo", "barr", "baz"];
+    /// {
+    ///     let mut writer = RecordWriter::new(Rc::get_mut(&mut rc).unwrap());
+    ///     for rec in records.iter() {
+    ///         writer.write_record(rec.as_bytes()).unwrap();
+    ///     }
+    /// }
+    /// let read = std::io::BufReader::new(Cursor::new(buf));
+    /// let mut reader = RecordReader::new(read);
+    /// let mut vec = Vec::new();
+    /// while let Ok(Some(len)) = reader.peek_next_len() {
+    ///     let len = len as usize;
+    ///     if vec.len() < len {
+    ///         vec.resize(len, 0);
+    ///     }
+    ///     let next = reader.read_next(&mut vec[0..len]);
+    ///     assert_eq!(next.unwrap().unwrap(), len);
+    ///     // &vec[0..len] contains the bytes of this record
+    /// }
+    /// assert_eq!(vec.len(), 4);
+    /// ```
+    ///
+    pub fn read_next(&mut self, buf: &mut [u8]) -> Result<Option<usize>, RecordReadError> {
+        let len = match self.read_next_len_unchecked()? {
+            Some(len) => len,
+            None => return Ok(None),
+        };
+        if (buf.len() as u64) < len {
+            self.reader.seek(SeekFrom::Current(8 + len as i64))?;
+            return Err(RecordReadError::BufferTooShort { needed: len });
+        }
+        let mut len_bytes = [0u8; 8];
+        LittleEndian::write_u64(&mut len_bytes, len);
+        let len_ok = self.checksum(&mut len_bytes)?;
+
+        let slice = &mut buf[0..len as usize];
+        self.read_bytes_exact_unchecked(slice)?;
+        let bytes_ok = self.checksum(slice)?;
+
+        if bytes_ok && len_ok {
+            return Ok(Some(len as usize));
+        } else {
+            if !len_ok {
+                return Err(RecordReadError::CorruptFile);
+            }
+            return Err(RecordReadError::CorruptRecord);
+        }
+    }
+    /// Allocate a Vec<u8> on the heap and read the next record into it.
+    /// Returns the filled Vec, if successful.
+    /// Returns None, if it could read exactly 0 bytes (indicating EOF)
+    /// # Example
+    /// ```
+    /// use tensorflow::io::{RecordReadError, RecordReader, RecordWriter};
+    /// use std::{io::Cursor, rc::Rc};
+    /// let mut buf = Vec::new();
+    /// let mut rc = Rc::new(&mut buf);
+    /// let records = vec!["foo", "barr", "baz"];
+    /// {
+    ///     let mut writer = RecordWriter::new(Rc::get_mut(&mut rc).unwrap());
+    ///     for rec in records.iter() {
+    ///         writer.write_record(rec.as_bytes()).unwrap();
+    ///     }
+    /// }
+    /// let read = std::io::BufReader::new(Cursor::new(buf));
+    /// let mut reader = RecordReader::new(read);
+    /// let mut i = 0;
+    /// loop {
+    ///     let next = reader.read_next_owned();
+    ///     match next {
+    ///         Ok(res) => match res {
+    ///             Some(vec) => assert_eq!(&vec[..], records[i].as_bytes()),
+    ///             None => break,
+    ///         },
+    ///         Err(RecordReadError::CorruptFile) | Err(RecordReadError::IoError { .. }) => {
+    ///             break;
+    ///         }
+    ///         _ => {}
+    ///     }
+    ///     i += 1;
+    /// }
+    /// ```
+    pub fn read_next_owned(&mut self) -> Result<Option<Vec<u8>>, RecordReadError> {
+        let len = match self.read_next_len_unchecked()? {
+            Some(len) => len,
+            None => return Ok(None),
+        };
+        let mut vec = vec![0u8; len as usize];
+        let mut len_bytes = [0u8; 8];
+        LittleEndian::write_u64(&mut len_bytes, len);
+        let len_ok = self.checksum(&mut len_bytes)?;
+        self.read_bytes_exact_unchecked(&mut vec)?;
+        let bytes_ok = self.checksum(&vec)?;
+        if bytes_ok && len_ok {
+            return Ok(Some(vec));
+        } else {
+            if !len_ok {
+                return Err(RecordReadError::CorruptFile);
+            }
+            return Err(RecordReadError::CorruptRecord);
+        }
+    }
+    /// Convert the Reader into an Iterator<Item = Result<Vec<u8>, RecordReadError>, which iterates
+    /// the whole Read. Stops if it finds whole-file corruption.
+    /// # Example
+    /// ```
+    /// use tensorflow::io::{RecordWriter, RecordReader};
+    /// let records = vec!["Foo bar baz", "boom bing bang", "sum soup shennaninganner"];
+    /// let path = "test_resources/io/roundtrip.tfrecord";
+    /// let out = ::std::fs::OpenOptions::new()
+    ///     .write(true)
+    ///     .create(true)
+    ///     .open(path)
+    ///     .unwrap();
+    /// {
+    ///     let mut writer = RecordWriter::new(out);
+    ///     for rec in records.iter() {
+    ///         writer.write_record(rec.as_bytes()).unwrap();
+    ///     }
+    /// }
+    /// {
+    ///     let actual = ::std::fs::OpenOptions::new().read(true).open(path).unwrap();
+    ///     let reader = RecordReader::new(actual);
+    ///     for (actual, expected) in reader.into_iter_owned().zip(records) {
+    ///         assert_eq!(actual.unwrap(), expected.as_bytes());
+    ///     }
+    /// }
+    /// {
+    ///     let actual = ::std::fs::OpenOptions::new().read(true).open(path).unwrap();
+    ///     let reader = RecordReader::new(actual);
+    ///     assert_eq!(reader.into_iter_owned().count(), 3);
+    /// }
+    /// let _ = std::fs::remove_file(path);
+    /// ```
+    pub fn into_iter_owned(self) -> impl Iterator<Item = Result<Vec<u8>, RecordReadError>> {
+        RecordOwnedIterator { records: self }
+    }
+}
+
+struct RecordOwnedIterator<R: Read + Seek> {
+    records: RecordReader<R>,
+}
+
+impl<R: Read + Seek> Iterator for RecordOwnedIterator<R> {
+    type Item = Result<Vec<u8>, RecordReadError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.records.read_next_owned().transpose() {
+            Some(Err(RecordReadError::CorruptFile)) => None,
+            rest @ _ => rest,
+        }
     }
 }
 
@@ -84,14 +384,95 @@ mod tests {
                 .write_record("The Quick Brown Fox".as_bytes())
                 .unwrap();
         }
+        {
+            let mut af = File::open(actual_filename).unwrap();
+            let mut ef = File::open(expected_filename).unwrap();
+            let mut actual = vec![0; 0];
+            let mut expected = vec![0; 0];
+            af.read_to_end(&mut actual).unwrap();
+            ef.read_to_end(&mut expected).unwrap();
 
-        let mut af = File::open(actual_filename).unwrap();
-        let mut ef = File::open(expected_filename).unwrap();
-        let mut actual = vec![0; 0];
-        let mut expected = vec![0; 0];
-        af.read_to_end(&mut actual).unwrap();
-        ef.read_to_end(&mut expected).unwrap();
+            assert_eq!(actual, expected);
+        }
 
-        assert_eq!(actual, expected);
+        let _ = std::fs::remove_file(actual_filename);
+    }
+    #[test]
+    fn peek_next() {
+        use std::{io::Cursor, rc::Rc};
+        let mut buf = Vec::new();
+        let mut rc = Rc::new(&mut buf);
+        let records = vec!["foo", "barr", "baz"];
+        {
+            let mut writer = RecordWriter::new(Rc::get_mut(&mut rc).unwrap());
+            for rec in records.iter() {
+                writer.write_record(rec.as_bytes()).unwrap();
+            }
+        }
+        let read = std::io::BufReader::new(Cursor::new(buf));
+        let mut reader = RecordReader::new(read);
+        let mut ary = [0u8; 4];
+        let mut i = 0;
+        loop {
+            if i < 3 {
+                assert_eq!(
+                    reader.peek_next_len().unwrap().unwrap() as usize,
+                    records[i].len()
+                );
+            }
+            if i == 3 {
+                assert!(reader.peek_next_len().unwrap().is_none());
+            }
+
+            let next = reader.read_next(&mut ary);
+            match next {
+                Ok(res) => match res {
+                    Some(len) => assert_eq!(&ary[0..len], records[i].as_bytes()),
+                    None => break,
+                },
+                Err(RecordReadError::CorruptFile) | Err(RecordReadError::IoError { .. }) => {
+                    break;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+
+    #[test]
+    fn seek_over_too_long() {
+        use std::{io::Cursor, rc::Rc};
+        let mut buf = Vec::new();
+        let mut rc = Rc::new(&mut buf);
+        let records = vec!["foo", "barr", "baz"];
+        {
+            let mut writer = RecordWriter::new(Rc::get_mut(&mut rc).unwrap());
+            for rec in records.iter() {
+                writer.write_record(rec.as_bytes()).unwrap();
+            }
+        }
+        let read = std::io::BufReader::new(Cursor::new(buf));
+        let mut reader = RecordReader::new(read);
+        let mut ary = [0u8; 3];
+        let mut i = 0;
+        loop {
+            let next = reader.read_next(&mut ary);
+            if i == 0 {
+                assert_eq!(next.unwrap().unwrap(), 3);
+                assert_eq!(&ary, records[i].as_bytes());
+            } else if i == 1 {
+                let buffer_too_short = match next {
+                    Err(RecordReadError::BufferTooShort { needed: v }) => v == 4,
+                    _ => false,
+                };
+                assert!(buffer_too_short);
+            } else if i == 2 {
+                assert_eq!(next.unwrap().unwrap(), 3);
+                assert_eq!(&ary, records[i].as_bytes());
+            } else {
+                break;
+            }
+            i += 1;
+        }
     }
 }


### PR DESCRIPTION
I guess I left the work unfinished when I submitted RecordWriter a few years ago. I was hoping some upstream issues would be resolved (e.g., GATs for efficient iteration, and I was expecting the Read trait to change to deal with the uninitialized buffers problem).

I think this is the best that can be done for right now, and it's better to have something than nothing.