### PR TITLE
Add back std:: to io

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -139,7 +139,7 @@ fn extract<P: AsRef<Path>, P2: AsRef<Path>>(archive_path: P, extract_to: P2) {
                     }
                 }
                 let mut outfile = File::create(&output_path).unwrap();
-                io::copy(&mut zipfile, &mut outfile).unwrap();
+                std::io::copy(&mut zipfile, &mut outfile).unwrap();
             }
         }
     }


### PR DESCRIPTION
 Hello, https://github.com/tensorflow/rust/commit/713daef09a22b47ae97d529b8ae43b6866291df5 removed `self` from io, however it was used under this compilation target. I just added it to the target itself instead of back at the top so it doesn't give unused warnings when not msvc