### PR TITLE
Test for get_bool_list/set_bool_list

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2628,6 +2628,17 @@ mod tests {
         );
         assert_eq!(42, op.get_attr_int("seed").unwrap());
 
+        // Issue #289
+        let op = {
+            let mut nd = g.new_operation("CheckBools", "CheckBools").unwrap();
+            nd.set_attr_bool_list("attr1", &[true, true]).unwrap();
+            nd.finish().unwrap()
+        };
+        assert_eq!(
+            &[true, true],
+            &op.get_attr_bool_list("attr1").unwrap() as &[bool]
+        );
+
         // TODO: Support get_attr_*/set_attr_*:
         // - bool_list
         // - tensor_list


### PR DESCRIPTION
Hi,

This is my first ever contribution to a rust project. Please, let me know if the code is lacking in any way.

While setting the boolean list attribute, I couldn't find/think of any attribute with a type of boolean list. So, right now, it is just given  a random name `attr1`. Could you please suggest an appropriate attribute to use in its place?

Issue #289

Signed-off-by: Tejas Sanap <sanap.tejas@gmail.com>