### PR TITLE
upgrade to tensorflow 2.4.0

### DIFF
--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -24,8 +24,8 @@ const REPOSITORY: &'static str = "https://github.com/tensorflow/tensorflow.git";
 const FRAMEWORK_TARGET: &'static str = "tensorflow:libtensorflow_framework";
 const TARGET: &'static str = "tensorflow:libtensorflow";
 // `VERSION` and `TAG` are separate because the tag is not always `'v' + VERSION`.
-const VERSION: &'static str = "2.3.0";
-const TAG: &'static str = "v2.3.0";
+const VERSION: &'static str = "2.4.0";
+const TAG: &'static str = "v2.4.0";
 const MIN_BAZEL: &'static str = "0.5.4";
 
 macro_rules! get(($name:expr) => (ok!(env::var($name))));


### PR DESCRIPTION
I've got a model built and saved with preprocessing layers on tensorflow 2.4.0 that fails to load with

```
Error: {inner:0x7fc3bfcf3da0, NotFound: Op type not registered 'DenseBincount' in binary running on <mypc>. Make sure the Op and Kernel are registered in the binary running in this process. Note that if you are loading a saved graph which used ops from tf.contrib, accessing (e.g.) `tf.contrib.resampler` should be done before importing the graph, as contrib ops are lazily registered when the module is first accessed.}
```

Upgrading the version in the build.rs file fixes it