### PR TITLE
Add Scope::with_kernel_label

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -162,7 +162,7 @@ impl Scope {
             },
             device: self.device.clone(),
             control_deps: self.control_deps.clone(),
-            kernel_label: "".to_string(),
+            kernel_label: self.kernel_label.clone(),
         }
     }
 
@@ -177,7 +177,7 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: self.device.clone(),
             control_deps: self.control_deps.clone(),
-            kernel_label: "".to_string(),
+            kernel_label: self.kernel_label.clone(),
         }
     }
 
@@ -217,7 +217,7 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: device.to_string(),
             control_deps: self.control_deps.clone(),
-            kernel_label: "".to_string(),
+            kernel_label: self.kernel_label.clone(),
         }
     }
 
@@ -238,7 +238,7 @@ impl Scope {
                 .chain(control_deps.iter())
                 .cloned()
                 .collect(),
-            kernel_label: "".to_string(),
+            kernel_label: self.kernel_label.clone(),
         }
     }
 
@@ -253,7 +253,7 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: self.device.clone(),
             control_deps: vec![],
-            kernel_label: "".to_string(),
+            kernel_label: self.kernel_label.clone(),
         }
     }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -102,6 +102,7 @@ pub struct Scope {
     op_names: Rc<RefCell<HashMap<String, i32>>>,
     device: String,
     control_deps: Vec<Operation>,
+    kernel_label: String,
 }
 
 impl Scope {
@@ -117,6 +118,7 @@ impl Scope {
             op_names: Rc::new(RefCell::new(HashMap::new())),
             device: "".to_string(),
             control_deps: Vec::new(),
+            kernel_label: "".to_string(),
         }
     }
 
@@ -160,6 +162,7 @@ impl Scope {
             },
             device: self.device.clone(),
             control_deps: self.control_deps.clone(),
+            kernel_label: "".to_string(),
         }
     }
 
@@ -174,6 +177,7 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: self.device.clone(),
             control_deps: self.control_deps.clone(),
+            kernel_label: "".to_string(),
         }
     }
 
@@ -213,6 +217,7 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: device.to_string(),
             control_deps: self.control_deps.clone(),
+            kernel_label: "".to_string(),
         }
     }
 
@@ -233,6 +238,7 @@ impl Scope {
                 .chain(control_deps.iter())
                 .cloned()
                 .collect(),
+            kernel_label: "".to_string(),
         }
     }
 
@@ -247,6 +253,22 @@ impl Scope {
             op_names: self.op_names.clone(),
             device: self.device.clone(),
             control_deps: vec![],
+            kernel_label: "".to_string(),
+        }
+    }
+
+    /// Return a new scope. All ops created with the new scope will have
+    /// kernel_label as the value for their '_kernel' attribute;
+    pub fn with_kernel_label(&self, kernel_label: &str) -> Scope {
+        Scope {
+            graph: self.graph.clone(),
+            name: self.name.clone(),
+            children_names: self.children_names.clone(),
+            op_name: self.op_name.clone(),
+            op_names: self.op_names.clone(),
+            device: self.device.clone(),
+            control_deps: self.control_deps.clone(),
+            kernel_label: kernel_label.to_string(),
         }
     }
 
@@ -262,6 +284,9 @@ impl Scope {
         nd.set_device(&self.device)?;
         for control_dep in &self.control_deps {
             nd.add_control_input(control_dep);
+        }
+        if !self.kernel_label.is_empty() {
+            nd.set_attr_string("_kernel", &self.kernel_label)?;
         }
         f(&mut nd)?;
         Ok(nd.finish()?)
@@ -328,6 +353,19 @@ mod tests {
                 .new_operation("NoOp", |_| Ok(()))
                 .unwrap()
                 .device()
+                .unwrap(),
+            "foo"
+        );
+    }
+
+    #[test]
+    fn kernel_label() {
+        assert_eq!(
+            Scope::new_root_scope()
+                .with_kernel_label("foo")
+                .new_operation("NoOp", |_| Ok(()))
+                .unwrap()
+                .get_attr_string("_kernel")
                 .unwrap(),
             "foo"
         );

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -258,7 +258,7 @@ impl Scope {
     }
 
     /// Return a new scope. All ops created with the new scope will have
-    /// kernel_label as the value for their '_kernel' attribute;
+    /// kernel_label as the value for their '_kernel' attribute.
     pub fn with_kernel_label(&self, kernel_label: &str) -> Scope {
         Scope {
             graph: self.graph.clone(),


### PR DESCRIPTION
Implement with_kernel_label for Scope including:

- Add kernel_label field to Scope.
- Set the field with Scope::with_kernel_label.
- Update new_operation to set the corresponding attr.
