### PR TITLE
Support Tensor::from and Shape::from for arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ half = "1.7.1"
 protobuf = "=2.23.0"
 # Enables conversions between ndarray::Array objects and tensorflow::Tensor
 ndarray = { version = "0.15.3", optional = true }
-
+rustversion = "1.0.5"
 
 [dev-dependencies]
 random = "0.12.2"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ so if you are unsure please [check out the docs](https://www.tensorflow.org/inst
 Some of the examples use TensorFlow code written in Python and require a full TensorFlow
 installation.
 
+The minimum supported Rust version is 1.49.
+
 ### Usage
 Add this to your `Cargo.toml`:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,7 @@ Note that any crate not mentioned here (e.g. tensorflow-proto-codegen, tensorflo
 1. Check out a clean copy.  Note that `cargo publish` packages up untracked files.  Use `--allow-dirty` at your peril.
 1. Fetch from the main repo
 1. Ensure that the TensorFlow version is a real release, not a release candidate
+1. Ensure that the minimum supported Rust version in the README is up to date
 1. Update changelog.
 1. Bump version number of `tensorflow-sys` if necessary
    1. Run `git log v${PREVIOUS_VERSION}..HEAD tensorflow-sys` and see if there were any changes. If not, skip.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1420,6 +1420,20 @@ impl<'a, T: TensorType> From<&'a [T]> for Tensor<T> {
     }
 }
 
+#[rustversion::since(1.51)]
+impl<'a, T: TensorType, const N: usize> From<[T; N]> for Tensor<T> {
+    fn from(data: [T; N]) -> Tensor<T> {
+        Tensor::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<'a, T: TensorType, const N: usize> From<&[T; N]> for Tensor<T> {
+    fn from(data: &[T; N]) -> Tensor<T> {
+        Tensor::from(&data[..])
+    }
+}
+
 #[cfg(feature = "ndarray")]
 /// Convert any ndarray::ArrayBase type into a tensorflow::Tensor
 impl<T, S, D> From<ArrayBase<S, D>> for Tensor<T>
@@ -2033,14 +2047,78 @@ macro_rules! shape_from_array {
     };
 }
 
+#[rustversion::not(since(1.51))]
 shape_from_array!(0);
+#[rustversion::not(since(1.51))]
 shape_from_array!(1);
+#[rustversion::not(since(1.51))]
 shape_from_array!(2);
+#[rustversion::not(since(1.51))]
 shape_from_array!(3);
+#[rustversion::not(since(1.51))]
 shape_from_array!(4);
+#[rustversion::not(since(1.51))]
 shape_from_array!(5);
+#[rustversion::not(since(1.51))]
 shape_from_array!(6);
+#[rustversion::not(since(1.51))]
 shape_from_array!(7);
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<[i32; N]> for Shape {
+    fn from(data: [i32; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<[u32; N]> for Shape {
+    fn from(data: [u32; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<[i64; N]> for Shape {
+    fn from(data: [i64; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<[u64; N]> for Shape {
+    fn from(data: [u64; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<&[i32; N]> for Shape {
+    fn from(data: &[i32; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<&[u32; N]> for Shape {
+    fn from(data: &[u32; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<&[i64; N]> for Shape {
+    fn from(data: &[i64; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
+
+#[rustversion::since(1.51)]
+impl<const N: usize> From<&[u64; N]> for Shape {
+    fn from(data: &[u64; N]) -> Shape {
+        Shape::from(&data[..])
+    }
+}
 
 impl Into<Option<Vec<Option<i64>>>> for Shape {
     fn into(self) -> Option<Vec<Option<i64>>> {
@@ -2247,6 +2325,20 @@ mod tests {
         assert_ne!(a, d);
     }
 
+    #[rustversion::since(1.51)]
+    #[test]
+    fn tensor_from_array() {
+        let x = Tensor::<i32>::from([1, 2, 3]);
+        assert_eq!(x.as_ref(), &[1, 2, 3]);
+    }
+
+    #[rustversion::since(1.51)]
+    #[test]
+    fn tensor_from_array_ref() {
+        let x = Tensor::<i32>::from(&[1, 2, 3]);
+        assert_eq!(x.as_ref(), &[1, 2, 3]);
+    }
+
     #[test]
     fn tensor_display() {
         let tests = [
@@ -2346,5 +2438,23 @@ mod tests {
     #[test]
     fn shape_from_array1_ref() {
         assert_eq!(Shape::from(&[1]), Shape::from(&[1][..]));
+    }
+
+    #[rustversion::since(1.51)]
+    #[test]
+    fn shape_from_array8() {
+        assert_eq!(
+            Shape::from([1, 2, 3, 4, 5, 6, 7, 8]),
+            Shape::from(&[1, 2, 3, 4, 5, 6, 7, 8][..])
+        );
+    }
+
+    #[rustversion::since(1.51)]
+    #[test]
+    fn shape_from_array8_ref() {
+        assert_eq!(
+            Shape::from(&[1, 2, 3, 4, 5, 6, 7, 8]),
+            Shape::from(&[1, 2, 3, 4, 5, 6, 7, 8][..])
+        );
     }
 }

--- a/test-all
+++ b/test-all
@@ -58,7 +58,7 @@ run cargo doc -vv --features tensorflow_unstable,private-docs-rs
 (cd tensorflow-sys && run cargo run --example tf_version)
 (cd tensorflow-sys && run cargo doc -vv)
 
-for file in $(find -name '*.rs'); do
+for file in $(find . -name target -prune -o -name '*.rs' -print); do
     bad_deprecations="$(rustfmt --emit stdout --config max_width=1000 "$file" | grep '#\[deprecated' | grep -E -v '([^"\\]|\\.|"([^"\\]|\\.)*")*since' || true)"
     if [[ "${bad_deprecations}" != "" ]]; then
         echo "ERROR: #[deprecated] attribute(s) found with no 'since' key in $file:"


### PR DESCRIPTION
This allows writing e.g. `Tensor::from([1, 2, 3])` or `Shape::from([1, 2, 3])` instead of requiring `Tensor::from(&[1, 2, 3][..])` or `Shape::from(&[1, 2, 3][..])`.

This relies on const generics and so only works for Rust 1.51 and above. The library will still compile with older versions, just without this new feature.