### PR TITLE
Port CI tests to GitHub Actions --- Part 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Handle line endings automatically for files detected as text
 # and leave all files detected as binary untouched.
+*.rs text eol=lf
 * text=auto
 
 # Check for whitespace errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+name: Continuous integration
+
+env:
+  CARGO_TERM_COLOR: always
+  TF_RUST_BUILD_FROM_SRC: false
+  # RUSTFLAGS: "-D warnings"  # it needs some works to enable this flag
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - name: Execute test-all
+        run: ./test-all
+        shell: bash
+#  clippy:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        rust:
+#          - beta
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          override: true
+#          components: clippy
+#      - run: cargo clippy


### PR DESCRIPTION
This PR tries to port CI tests to GitHub Actions. While #316 is for the same purpose, which is not active recently so I opened as a different PR.

The current target platforms in the configuration are Ubuntu, macOS, and Windows, with the latest stable channel Rust version. In addition, `.gitattribute` was modified to support the CI on the Windows env.

The clippy checking might be helpful, but it generates lots of warnings currently so they are commented out now.

resolves #301
