### PR TITLE
`private-docs-rs` feature should be propagated to tensorflow-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tensorflow_unstable = []
 eager = ["tensorflow-sys/eager"]
 # This is for testing purposes; users should not use this.
 examples_system_alloc = ["tensorflow-sys/examples_system_alloc"]
-private-docs-rs = [] # DO NOT RELY ON THIS
+private-docs-rs = ["tensorflow-sys/private-docs-rs"] # DO NOT RELY ON THIS
 
 [workspace]
 


### PR DESCRIPTION
The private-docs-rs feature was introduced to avoid large file downloading when building docs in docs.rs. However, this trigger was not propagated to `tensorflow-sys` which have broken [the tensorflow doc in docs.rs](https://docs.rs/crate/tensorflow/0.17.0). This patch is trying to resolve the following issues:

Resolves #255
Resolves #335