### PR TITLE
Introduce ToTensorHandle trait and its implementations. 

### DIFF
--- a/src/eager.rs
+++ b/src/eager.rs
@@ -63,6 +63,13 @@ impl<'a, T: TensorType> ToTensorHandle<'a> for [T] {
     }
 }
 
+impl<'a, T: TensorType, const N: usize> ToTensorHandle<'a> for [T; N] {
+    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
+        let tensor = Tensor::from(&self[..]);
+        TensorHandle::new(ctx, &tensor)
+    }
+}
+
 #[cfg(feature = "ndarray")]
 /// Convert any ndarray::ArrayBase type into a TensorHandle
 impl<'a, T, S, D> ToTensorHandle<'a> for ArrayBase<S, D>

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -15,9 +15,6 @@ pub use op::raw_ops;
 
 use crate::{Result, Tensor, TensorType};
 
-#[cfg(feature = "ndarray")]
-use ndarray::{ArrayBase, Data, Dimension};
-
 /// A helper trait to convert a Tensor or some other types into a TensorHandle
 /// for use in eager execution.
 pub trait ToTensorHandle<'a> {
@@ -43,49 +40,6 @@ where
 impl<'a> ToTensorHandle<'a> for TensorHandle<'a> {
     fn to_handle(&self, _: &'a Context) -> Result<TensorHandle<'a>> {
         self.copy_sharing_tensor()
-    }
-}
-
-impl<'a, T: TensorType> ToTensorHandle<'a> for T {
-    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
-        let mut tensor = Tensor::<T>::new(&[]);
-        tensor[0] = self.clone();
-        TensorHandle::new(ctx, &tensor)
-    }
-}
-
-impl<'a, T: TensorType> ToTensorHandle<'a> for [T] {
-    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
-        let mut tensor = Tensor::<T>::new(&[self.len() as u64]);
-        for (e, v) in tensor.iter_mut().zip(self) {
-            e.clone_from(v);
-        }
-        TensorHandle::new(ctx, &tensor)
-    }
-}
-
-impl<'a, T: TensorType, const N: usize> ToTensorHandle<'a> for [T; N] {
-    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
-        let tensor = Tensor::from(&self[..]);
-        TensorHandle::new(ctx, &tensor)
-    }
-}
-
-#[cfg(feature = "ndarray")]
-/// Convert any ndarray::ArrayBase type into a TensorHandle
-impl<'a, T, S, D> ToTensorHandle<'a> for ArrayBase<S, D>
-where
-    T: TensorType,
-    S: Data<Elem = T>,
-    D: Dimension,
-{
-    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
-        let dims: Vec<u64> = self.shape().iter().map(|x| *x as u64).collect();
-        let mut tensor: Tensor<T> = Tensor::new(&dims);
-        for (e, v) in tensor.iter_mut().zip(self.iter()) {
-            e.clone_from(v);
-        }
-        TensorHandle::new(ctx, &tensor)
     }
 }
 
@@ -149,54 +103,6 @@ mod tests {
         let handle2 = handle.to_handle(&ctx).unwrap();
         let tensor2: Tensor<i32> = handle2.resolve().unwrap();
         assert_eq!(&tensor[..], &tensor2[..]);
-    }
-
-    #[test]
-    fn tensortype_to_handle() {
-        let ctx = Context::new(ContextOptions::new()).unwrap();
-        let v = 1i32;
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<i32> = handle.resolve().unwrap();
-        assert_eq!(&[v], &tensor[..]);
-
-        let v = 1i64;
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<i64> = handle.resolve().unwrap();
-        assert_eq!(&[v], &tensor[..]);
-
-        let v = 1f32;
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<f32> = handle.resolve().unwrap();
-        assert_eq!(&[v], &tensor[..]);
-
-        let v = 1f64;
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<f64> = handle.resolve().unwrap();
-        assert_eq!(&[v], &tensor[..]);
-    }
-
-    #[test]
-    fn tarray_to_handle() {
-        let ctx = Context::new(ContextOptions::new()).unwrap();
-        let v = [1i32, 2, 3, 4];
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<i32> = handle.resolve().unwrap();
-        assert_eq!(&v, &tensor[..]);
-
-        let v = [1i64, 2, 3, 4];
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<i64> = handle.resolve().unwrap();
-        assert_eq!(&v, &tensor[..]);
-
-        let v = [1f32, 2.0, 3.0, 4.0];
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<f32> = handle.resolve().unwrap();
-        assert_eq!(&v, &tensor[..]);
-
-        let v = [1f64, 2.0, 3.0, 4.0];
-        let handle = v.to_handle(&ctx).unwrap();
-        let tensor: Tensor<f64> = handle.resolve().unwrap();
-        assert_eq!(&v, &tensor[..]);
     }
 
     #[cfg(feature = "ndarray")]

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -99,6 +99,29 @@ mod tests {
     use ndarray::array;
 
     #[test]
+    fn underlying_memories() {
+        // This test is to ensure that the eager execution API does not
+        // break the Rust's memory design.
+
+        let ctx = Context::new(ContextOptions::new()).unwrap();
+
+        // Create a tensor with a single element
+        let t: Tensor<i32> = Tensor::from(0);
+
+        // Create a handle to the tensor
+        let h = t.to_handle(&ctx).unwrap();
+
+        // Get a tensor as mutable from the handle
+        let mut t2: Tensor<i32> = h.resolve().unwrap();
+
+        // According to the Rust's memory design, the following assignment should affect only the tensor `t2`.
+        t2[0] = 1;
+
+        // Since the tensor `t` is immutable and expected not to be modified, `t` and `t2` should not be equal.
+        assert_ne!(t[0], t2[0]);
+    }
+
+    #[test]
     fn tensor_to_handle() {
         let ctx = Context::new(ContextOptions::new()).unwrap();
         let tensor = Tensor::<i32>::new(&[1, 2, 3, 4]);

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -18,15 +18,16 @@ use crate::{Result, Tensor, TensorType};
 #[cfg(feature = "ndarray")]
 use ndarray::{ArrayBase, Data, Dimension};
 
-/// Simple helper trait to convert a Tensor into a TensorHandle for use in eager
-/// execution.
+/// A helper trait to convert a Tensor or some other types into a TensorHandle
+/// for use in eager execution.
 pub trait ToTensorHandle<'a> {
-    /// Convert the Tensor or TensorHandle into a new TensorHandle.
+    /// Convert a Tensor or values into a new TensorHandle.
     ///
     /// _Warning_ : This function may create multiple handles to the same
     /// underlying tensor. Users should be careful not to modify the tensor
-    /// after converting it to a handle. Also, users should be careful not
-    /// to modify the tensor obtained via the TensorHandle's `resolve` method.
+    /// after converting it to a TensorHandle. Also, users should be careful
+    /// not to modify the Tensor generated from the TensorHandle's `resolve`
+    /// method.
     fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>>;
 }
 

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -32,12 +32,6 @@ impl<T: TensorType> Tensor<T> {
 /// for use in eager execution.
 pub trait ToTensorHandle<'a> {
     /// Convert a Tensor or values into a new TensorHandle.
-    ///
-    /// _Warning_ : This function may create multiple handles to the same
-    /// underlying tensor. Users should be careful not to modify the tensor
-    /// after converting it to a TensorHandle. Also, users should be careful
-    /// not to modify the Tensor generated from the TensorHandle's `resolve`
-    /// method.
     fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>>;
 }
 

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -88,6 +88,7 @@ where
         TensorHandle::new(ctx, &tensor)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -12,3 +12,69 @@ pub use tensor_handle::*;
 mod op;
 
 pub use op::raw_ops;
+
+use crate::{Result, Tensor, TensorType};
+
+/// Simple helper trait to convert a Tensor into a TensorHandle for use in eager
+/// execution.
+pub trait ToTensorHandle<'a> {
+    /// Convert the Tensor or TensorHandle into a new TensorHandle.
+    ///
+    /// _Warning_ : This function may create multiple handles to the same
+    /// underlying tensor. Users should be careful not to modify the tensor
+    /// after converting it to a handle. Also, users should be careful not
+    /// to modify the tensor obtained via the TensorHandle's `resolve` method.
+    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>>;
+}
+
+impl<'a, T> ToTensorHandle<'a> for Tensor<T>
+where
+    T: TensorType,
+{
+    fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
+        TensorHandle::new(ctx, self)
+    }
+}
+
+impl<'a> ToTensorHandle<'a> for TensorHandle<'a> {
+    fn to_handle(&self, _: &'a Context) -> Result<TensorHandle<'a>> {
+        self.copy_sharing_tensor()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eager::{Context, ContextOptions};
+    use crate::Tensor;
+
+    #[test]
+    fn tensor_to_handle() {
+        let ctx = Context::new(ContextOptions::new()).unwrap();
+        let tensor = Tensor::<i32>::new(&[1, 2, 3, 4]);
+        let handle = tensor.to_handle(&ctx).unwrap();
+        assert_eq!(handle.num_dims().unwrap(), 4);
+        assert_eq!(handle.dim(0).unwrap(), 1);
+        assert_eq!(handle.dim(1).unwrap(), 2);
+        assert_eq!(handle.dim(2).unwrap(), 3);
+        assert_eq!(handle.dim(3).unwrap(), 4);
+
+        let tensor = Tensor::<i32>::new(&[1, 2, 3, 4]);
+        let handle = &tensor.to_handle(&ctx).unwrap();
+        assert_eq!(handle.num_dims().unwrap(), 4);
+        assert_eq!(handle.dim(0).unwrap(), 1);
+        assert_eq!(handle.dim(1).unwrap(), 2);
+        assert_eq!(handle.dim(2).unwrap(), 3);
+        assert_eq!(handle.dim(3).unwrap(), 4);
+    }
+
+    #[test]
+    fn handle_to_handle() {
+        let ctx = Context::new(ContextOptions::new()).unwrap();
+        let tensor = Tensor::<i32>::new(&[1, 2, 3, 4]);
+        let handle = tensor.to_handle(&ctx).unwrap();
+        let handle2 = handle.to_handle(&ctx).unwrap();
+        let tensor2: Tensor<i32> = handle2.resolve().unwrap();
+        assert_eq!(&tensor[..], &tensor2[..]);
+    }
+}

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -102,7 +102,7 @@ mod tests {
         let handle = tensor.to_handle(&ctx).unwrap();
         let handle2 = handle.to_handle(&ctx).unwrap();
         let tensor2 = handle2.resolve::<i32>().unwrap();
-        let mut tensor2 = unsafe {tensor2.into_tensor()};
+        let mut tensor2 = unsafe { tensor2.into_tensor() };
         assert_eq!(tensor, tensor2);
 
         // Check that tensor and tensro2 share the same underlying data.

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -493,19 +493,6 @@ mod tests {
         let h_z = add(&ctx, &h_x, &h_y).unwrap();
         let z: Tensor<i32> = h_z.resolve().unwrap();
         assert_eq!(z, expected);
-
-        // handle and scaler
-        let expected2 = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
-        let h_z = add(&ctx, &h_x, &1i32).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
-        assert_eq!(z, expected2);
-
-        // tensor and array
-        let expected3 = Tensor::new(&[4]).with_values(&[2i32, 4, 6, 8]).unwrap();
-        let x = Tensor::new(&[4]).with_values(&values).unwrap();
-        let h_z = add(&ctx, &x, &values).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
-        assert_eq!(z, expected3);
     }
 
     #[cfg(feature = "tensorflow_gpu")]

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -441,7 +441,8 @@ mod tests {
         const NUMBER_OF_OUTPUTS: usize = 1;
         let [h] = op.execute::<NUMBER_OF_OUTPUTS>(&ctx).unwrap();
         let z: Tensor<i32> = h.resolve().unwrap();
-        assert_eq!(&z[..], &[2i32, 4, 6, 8]);
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 6, 8]).unwrap();
+        assert_eq!(z, expected);
     }
 
     #[test]
@@ -470,10 +471,27 @@ mod tests {
         let x = Tensor::new(&[2, 2]).with_values(&[1i32, 2, 3, 4]).unwrap();
         let h_x = TensorHandle::new(&ctx, &x).unwrap();
         let h_y = h_x.copy_sharing_tensor().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 6, 8]).unwrap();
 
+        // tensor and tensor
+        let h_z = add(&ctx, &x, &x).unwrap();
+        let z: Tensor<i32> = h_z.resolve().unwrap();
+        assert_eq!(z, expected);
+
+        // tensor and handle
+        let h_z = add(&ctx, &x, &h_y).unwrap();
+        let z: Tensor<i32> = h_z.resolve().unwrap();
+        assert_eq!(z, expected);
+
+        // handle and tensor
+        let h_z = add(&ctx, &h_x, &x).unwrap();
+        let z: Tensor<i32> = h_z.resolve().unwrap();
+        assert_eq!(z, expected);
+
+        // handle and handle
         let h_z = add(&ctx, &h_x, &h_y).unwrap();
         let z: Tensor<i32> = h_z.resolve().unwrap();
-        assert_eq!(&z[..], &[2i32, 4, 6, 8]);
+        assert_eq!(z, expected);
     }
 
     #[cfg(feature = "tensorflow_gpu")]

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -467,8 +467,9 @@ mod tests {
 
     #[test]
     fn test_raw_ops_add() {
+        let values = [1i32, 2, 3, 4];
         let ctx = Context::new(ContextOptions::new()).unwrap();
-        let x = Tensor::new(&[2, 2]).with_values(&[1i32, 2, 3, 4]).unwrap();
+        let x = Tensor::new(&[2, 2]).with_values(&values).unwrap();
         let h_x = TensorHandle::new(&ctx, &x).unwrap();
         let h_y = h_x.copy_sharing_tensor().unwrap();
         let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 6, 8]).unwrap();
@@ -492,6 +493,19 @@ mod tests {
         let h_z = add(&ctx, &h_x, &h_y).unwrap();
         let z: Tensor<i32> = h_z.resolve().unwrap();
         assert_eq!(z, expected);
+
+        // handle and scaler
+        let expected2 = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
+        let h_z = add(&ctx, &h_x, &1i32).unwrap();
+        let z: Tensor<i32> = h_z.resolve().unwrap();
+        assert_eq!(z, expected2);
+
+        // tensor and array
+        let expected3 = Tensor::new(&[4]).with_values(&[2i32, 4, 6, 8]).unwrap();
+        let x = Tensor::new(&[4]).with_values(&values).unwrap();
+        let h_z = add(&ctx, &x, &values).unwrap();
+        let z: Tensor<i32> = h_z.resolve().unwrap();
+        assert_eq!(z, expected3);
     }
 
     #[cfg(feature = "tensorflow_gpu")]

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -426,7 +426,10 @@ mod tests {
     #[test]
     fn test_add_op() {
         let ctx = Context::new(ContextOptions::new()).unwrap();
-        let x = Tensor::new(&[2, 2]).with_values(&[1i32, 2, 3, 4]).unwrap();
+        let x = Tensor::new(&[2, 2])
+            .with_values(&[1i32, 2, 3, 4])
+            .unwrap()
+            .freeze();
         let h_x = TensorHandle::new(&ctx, &x).unwrap();
         let h_y = h_x.copy_sharing_tensor().unwrap();
 
@@ -440,7 +443,7 @@ mod tests {
         // Execute Op
         const NUMBER_OF_OUTPUTS: usize = 1;
         let [h] = op.execute::<NUMBER_OF_OUTPUTS>(&ctx).unwrap();
-        let z: Tensor<i32> = h.resolve().unwrap();
+        let z = h.resolve::<i32>().unwrap();
         let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 6, 8]).unwrap();
         assert_eq!(z, expected);
     }
@@ -448,7 +451,10 @@ mod tests {
     #[test]
     fn test_invalid_add() {
         let ctx = Context::new(ContextOptions::new()).unwrap();
-        let x = Tensor::new(&[2, 2]).with_values(&[1i32, 2, 3, 4]).unwrap();
+        let x = Tensor::new(&[2, 2])
+            .with_values(&[1i32, 2, 3, 4])
+            .unwrap()
+            .freeze();
         let h_x = TensorHandle::new(&ctx, &x).unwrap();
         let h_y = h_x.copy_sharing_tensor().unwrap();
 
@@ -469,29 +475,29 @@ mod tests {
     fn test_raw_ops_add() {
         let values = [1i32, 2, 3, 4];
         let ctx = Context::new(ContextOptions::new()).unwrap();
-        let x = Tensor::new(&[2, 2]).with_values(&values).unwrap();
+        let x = Tensor::new(&[2, 2]).with_values(&values).unwrap().freeze();
         let h_x = TensorHandle::new(&ctx, &x).unwrap();
         let h_y = h_x.copy_sharing_tensor().unwrap();
         let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 6, 8]).unwrap();
 
         // tensor and tensor
         let h_z = add(&ctx, &x, &x).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
         assert_eq!(z, expected);
 
         // tensor and handle
         let h_z = add(&ctx, &x, &h_y).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
         assert_eq!(z, expected);
 
         // handle and tensor
         let h_z = add(&ctx, &h_x, &x).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
         assert_eq!(z, expected);
 
         // handle and handle
         let h_z = add(&ctx, &h_x, &h_y).unwrap();
-        let z: Tensor<i32> = h_z.resolve().unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
         assert_eq!(z, expected);
     }
 
@@ -510,7 +516,8 @@ mod tests {
 
         let x = Tensor::new(&[2, 2])
             .with_values(&[1.0f32, 2.0, 3.0, 4.0])
-            .unwrap();
+            .unwrap()
+            .freeze();
         let h = TensorHandle::new(&ctx, &x).unwrap();
         // Copy to GPU. This creates a new handle managed by the context `ctx`.
         let h_gpu = h.copy_to_device(&ctx, target_device).unwrap();
@@ -526,7 +533,7 @@ mod tests {
         let [h_z_gpu] = op.execute(&ctx).unwrap();
         assert!(&h_z_gpu.device_name().unwrap() == target_device);
 
-        let z: crate::Tensor<f32> = h_z_gpu.resolve().unwrap();
+        let z = h_z_gpu.resolve::<f32>().unwrap();
         let expected = [2.0f32, 4.0, 6.0, 8.0];
         for (v0, v1) in z.iter().zip(&expected) {
             assert!((v0 - v1).abs() < f32::EPSILON);

--- a/src/eager/op/op_test_util.rs
+++ b/src/eager/op/op_test_util.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 /// Code for Op's ut that mimics raw_opw.
-use crate::eager::TensorHandle;
+use crate::eager::{TensorHandle, ToTensorHandle};
 use crate::Result;
 
 use super::Op;
@@ -39,20 +39,24 @@ impl Add {
     }
 
     /// Execute add.
-    pub fn call<'a>(
+    pub fn call<'a, T0, T1>(
         &self,
         ctx: &'a crate::eager::Context,
-        x: &TensorHandle,
-        y: &TensorHandle,
-    ) -> Result<TensorHandle<'a>> {
+        x: &T0,
+        y: &T1,
+    ) -> Result<TensorHandle<'a>>
+    where
+        T0: ToTensorHandle<'a>,
+        T1: ToTensorHandle<'a>,
+    {
         // Define Op
 
         let op_name = "Add";
         let mut op = Op::new(ctx, op_name)?;
 
         // Required input arguments
-        op.add_input(&x)?;
-        op.add_input(&y)?;
+        op.add_input(&x.to_handle(ctx)?)?;
+        op.add_input(&y.to_handle(ctx)?)?;
 
         // Attributes
         if let ::std::option::Option::Some(value) = &self.T {
@@ -72,11 +76,11 @@ impl Add {
 }
 
 /// add with default options.
-pub fn add<'a>(
-    ctx: &'a crate::eager::Context,
-    x: &TensorHandle,
-    y: &TensorHandle,
-) -> Result<TensorHandle<'a>> {
+pub fn add<'a, T0, T1>(ctx: &'a crate::eager::Context, x: &T0, y: &T1) -> Result<TensorHandle<'a>>
+where
+    T0: ToTensorHandle<'a>,
+    T1: ToTensorHandle<'a>,
+{
     let op = Add::new();
     op.call(ctx, x, y)
 }

--- a/src/eager/readonly_tensor.rs
+++ b/src/eager/readonly_tensor.rs
@@ -6,8 +6,7 @@ use crate::{AnyTensor, DataType, Result, Shape, Tensor, TensorInner, TensorType}
 
 /// A read-only tensor.
 ///
-/// This ReadonlyTensor is a wrapper around a `Tensor` that is read-only.
-/// Some operations that mutate the underlying Tensor are not supported.
+/// ReadonlyTensor is a [`Tensor`](Tensor) that does not support mutation.
 #[derive(Debug, Clone, Eq)]
 pub struct ReadonlyTensor<T: TensorType> {
     pub(super) inner: T::InnerType,
@@ -54,7 +53,7 @@ impl<T: TensorType> ReadonlyTensor<T> {
     /// let mut a = Tensor::<i32>::new(&[2, 3, 5]);
     ///
     /// a[1*15 + 1*5 + 1] = 5;
-    /// let a = a.freeze();
+    /// let a: ReadonlyTensor<_> = a.freeze();
     /// assert_eq!(a.get(&[1, 1, 1]), 5);
     /// ```
     pub fn get(&self, indices: &[u64]) -> T {
@@ -67,7 +66,7 @@ impl<T: TensorType> ReadonlyTensor<T> {
     /// ```
     /// # use tensorflow::Tensor;
     /// # use tensorflow::eager::ReadonlyTensor;
-    /// let a = Tensor::<f32>::new(&[3, 3, 3]).freeze();
+    /// let a: ReadonlyTensor<_> = Tensor::<f32>::new(&[3, 3, 3]).freeze();
     ///
     /// assert_eq!(a.get_index(&[2, 2, 2]), 26);
     /// assert_eq!(a.get_index(&[1, 2, 2]), 17);

--- a/src/eager/readonly_tensor.rs
+++ b/src/eager/readonly_tensor.rs
@@ -1,0 +1,141 @@
+use libc::c_int;
+use std::ops::Deref;
+use tensorflow_sys as tf;
+
+use crate::{AnyTensor, DataType, Result, Shape, Tensor, TensorInner, TensorType};
+
+/// A read-only tensor.
+///
+/// This ReadonlyTensor is a wrapper around a `Tensor` that is read-only.
+/// Some operations that mutate the underlying Tensor are not supported.
+#[derive(Debug, Clone, Eq)]
+pub struct ReadonlyTensor<T: TensorType> {
+    pub(super) inner: T::InnerType,
+    pub(super) dims: Vec<u64>,
+}
+
+impl<T: TensorType> AnyTensor for ReadonlyTensor<T> {
+    fn inner(&self) -> Result<*mut tf::TF_Tensor> {
+        self.inner.as_mut_ptr(&self.dims)
+    }
+
+    fn data_type(&self) -> DataType {
+        T::data_type()
+    }
+}
+
+impl<T: TensorType> Deref for ReadonlyTensor<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        self.inner.deref()
+    }
+}
+
+impl<T: TensorType + PartialEq> PartialEq for ReadonlyTensor<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.dims == other.dims && self.deref() == other.deref()
+    }
+}
+
+impl<T: TensorType + PartialEq> PartialEq<Tensor<T>> for ReadonlyTensor<T> {
+    fn eq(&self, other: &Tensor<T>) -> bool {
+        self.dims == other.dims && self.deref() == other.deref()
+    }
+}
+
+impl<T: TensorType> ReadonlyTensor<T> {
+    /// Get one single value from the Tensor.
+    ///
+    /// ```
+    /// # use tensorflow::Tensor;
+    /// # use tensorflow::eager::ReadonlyTensor;
+    /// let mut a = Tensor::<i32>::new(&[2, 3, 5]);
+    ///
+    /// a[1*15 + 1*5 + 1] = 5;
+    /// let a = a.freeze();
+    /// assert_eq!(a.get(&[1, 1, 1]), 5);
+    /// ```
+    pub fn get(&self, indices: &[u64]) -> T {
+        let index = self.get_index(indices);
+        self[index].clone()
+    }
+
+    /// Get the array index from rows / columns indices.
+    ///
+    /// ```
+    /// # use tensorflow::Tensor;
+    /// # use tensorflow::eager::ReadonlyTensor;
+    /// let a = Tensor::<f32>::new(&[3, 3, 3]).freeze();
+    ///
+    /// assert_eq!(a.get_index(&[2, 2, 2]), 26);
+    /// assert_eq!(a.get_index(&[1, 2, 2]), 17);
+    /// assert_eq!(a.get_index(&[1, 2, 0]), 15);
+    /// assert_eq!(a.get_index(&[1, 0, 1]), 10);
+    /// ```
+    pub fn get_index(&self, indices: &[u64]) -> usize {
+        assert!(self.dims.len() == indices.len());
+        let mut index = 0;
+        let mut d = 1;
+        for i in (0..indices.len()).rev() {
+            assert!(self.dims[i] > indices[i]);
+            index += indices[i] * d;
+            d *= self.dims[i];
+        }
+        index as usize
+    }
+
+    /// Returns the tensor's dimensions.
+    pub fn dims(&self) -> &[u64] {
+        &self.dims
+    }
+
+    /// Returns the tensor's dimensions as a Shape.
+    pub fn shape(&self) -> Shape {
+        Shape(Some(self.dims.iter().map(|d| Some(*d as i64)).collect()))
+    }
+
+    // Wraps a TF_Tensor. Returns None if types don't match.
+    pub(super) unsafe fn from_tf_tensor(tensor: *mut tf::TF_Tensor) -> Option<Self> {
+        let mut dims = Vec::with_capacity(tf::TF_NumDims(tensor) as usize);
+        for i in 0..dims.capacity() {
+            dims.push(tf::TF_Dim(tensor, i as c_int) as u64);
+        }
+
+        Some(Self {
+            inner: T::InnerType::from_tf_tensor(tensor)?,
+            dims,
+        })
+    }
+
+    /// Convert back to a Tensor.
+    ///
+    /// Safety: This is unsafe because modifying the returned Tensor will modify the underlying memory,
+    /// which may affect other Tensors that share the same memory.
+    ///
+    /// ```
+    /// # use tensorflow::{Tensor, Result};
+    /// # use tensorflow::eager::*;
+    /// # fn main() -> Result<()> {
+    /// let ctx = Context::new(ContextOptions::new())?;
+    ///
+    /// let a_readonly = Tensor::<i32>::new(&[2, 3, 5]).freeze();
+    /// let h = a_readonly.to_handle(&ctx)?;
+    /// let b_readonly = h.resolve::<i32>()?;
+    ///
+    /// let mut b = unsafe { b_readonly.into_tensor() };
+    /// b[1*15 + 1*5 + 1] = 5;
+    ///
+    /// // Since a and b share the same memory, modifying b will also modify a.
+    /// assert_eq!(a_readonly, b);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub unsafe fn into_tensor(self) -> Tensor<T> {
+        Tensor {
+            inner: self.inner,
+            dims: self.dims,
+        }
+    }
+}

--- a/src/eager/readonly_tensor.rs
+++ b/src/eager/readonly_tensor.rs
@@ -92,7 +92,7 @@ impl<T: TensorType> ReadonlyTensor<T> {
 
     /// Returns the tensor's dimensions as a Shape.
     pub fn shape(&self) -> Shape {
-        Shape(Some(self.dims.iter().map(|d| Some(*d as i64)).collect()))
+        Shape::from(&self.dims[..])
     }
 
     // Wraps a TF_Tensor. Returns None if types don't match.

--- a/src/eager/tensor_handle.rs
+++ b/src/eager/tensor_handle.rs
@@ -25,6 +25,24 @@ use crate::{AnyTensor, DataType, Result, Status, TensorType};
 /// # }
 /// ```
 ///
+/// TensorHandle manages the same buffer of the tensor. Users can destruct the Tensor
+/// while leaving the TensorHandle. This is a valid use case for TensorHandle.
+/// ```
+/// # use tensorflow::{Result, Tensor};
+/// use tensorflow::eager::*;
+///
+/// # fn main() -> Result<()> {
+/// let opts = ContextOptions::new();
+/// let ctx = Context::new(opts)?;
+/// let h = {
+///     let t = Tensor::from(&[3i32]).freeze();
+///     TensorHandle::new(&ctx, &t)?
+/// };
+/// // At this point, the buffer is managed only by the handle.
+/// # Ok(())
+/// # }
+/// ```
+///
 /// Since TensorHandle cannot be alive beyond the lifetime of the context, the following
 /// code will not compile.
 /// ```compile_fail
@@ -37,12 +55,12 @@ use crate::{AnyTensor, DataType, Result, Status, TensorType};
 ///     let ctx = Context::new(opts)?;
 ///
 ///     let t = Tensor::from(&[3i32]).freeze();
-///     let h = TensorHandle::new(&ctx, &t)?;
-///     h
+///     TensorHandle::new(&ctx, &t)?
 /// };
 /// # Ok(())
 /// # }
 /// ```
+///
 #[derive(Debug)]
 pub struct TensorHandle<'a> {
     pub(super) inner: *mut tf::TFE_TensorHandle,

--- a/src/eager/tensor_handle.rs
+++ b/src/eager/tensor_handle.rs
@@ -327,7 +327,7 @@ mod tests {
                 .expect("No GPU device was found.");
             let target_device = &gpu_device.name;
 
-            let t = Tensor::new(&[2, 2]).with_values(&values).unwrap();
+            let t = Tensor::new(&[2, 2]).with_values(&values).unwrap().freeze();
             let h = TensorHandle::new(&ctx, &t).unwrap();
             let h_gpu = TensorHandle::copy_to_device(&h, &ctx, target_device).unwrap();
             assert_eq!(&h_gpu.device_name().unwrap(), target_device);
@@ -354,7 +354,7 @@ mod tests {
                 // Create a temporal Context
                 let opts = ContextOptions::new();
                 let ctx2 = Context::new(opts).unwrap();
-                let t = Tensor::new(&[2, 2]).with_values(&values).unwrap();
+                let t = Tensor::new(&[2, 2]).with_values(&values).unwrap().freeze();
 
                 // Create a TensorHandle managed by the context `ctx2`.
                 let h = TensorHandle::new(&ctx2, &t).unwrap();


### PR DESCRIPTION
This pull request introduces the ToTensorHandle trait to make the API for eager execution easier to handle.

I also tried to implement this trait for some types other than Tensor/TensorHandle. However, since this is before the implementation of raw_opw, it may be better to implement other types than Tensor/TensorHandle later.