### PR TITLE
Add ToTensorHandle implementations for other types.

### DIFF
--- a/src/eager.rs
+++ b/src/eager.rs
@@ -90,12 +90,7 @@ where
     D: Dimension,
 {
     fn to_handle(&self, ctx: &'a Context) -> Result<TensorHandle<'a>> {
-        let dims: Vec<u64> = self.shape().iter().map(|x| *x as u64).collect();
-        let mut tensor: Tensor<T> = Tensor::new(&dims);
-        for (e, v) in tensor.iter_mut().zip(self.iter()) {
-            e.clone_from(v);
-        }
-        tensor.into_handle(ctx)
+        Tensor::from(self).into_handle(ctx)
     }
 }
 

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -501,6 +501,44 @@ mod tests {
         assert_eq!(z, expected);
     }
 
+    #[test]
+    fn test_add_tensor_and_others() {
+        let values = [1i32, 2, 3, 4];
+        let ctx = Context::new(ContextOptions::new()).unwrap();
+
+        // h = [[1, 2],
+        //      [3, 4]]
+        let h = Tensor::new(&[2, 2])
+            .with_values(&values)
+            .unwrap()
+            .into_handle(&ctx)
+            .unwrap();
+
+        // tensor and scalar, braodcast
+        //  [[2, 3],  = [[1, 2],  + 1
+        //   [4, 5]]     [3, 4]]
+        let h_z = add(&ctx, &h, &1).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
+        assert_eq!(z, expected);
+
+        // tensor and array, broadcast
+        //  [[2, 3],  = [[1, 2],  + 1
+        //   [4, 5]]     [3, 4]]
+        let h_z = add(&ctx, &h, &[1]).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
+        assert_eq!(z, expected);
+
+        // handle and array (horizontal vector), broadcst
+        //  [[2, 4],  = [[1, 2],  + [1, 2]
+        //   [4, 6]]     [3, 4]]
+        let h_z = add(&ctx, &h, &[1, 2]).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 4, 6]).unwrap();
+        assert_eq!(z, expected);
+    }
+
     #[cfg(feature = "tensorflow_gpu")]
     #[test]
     #[ignore]

--- a/src/eager/op.rs
+++ b/src/eager/op.rs
@@ -423,6 +423,9 @@ mod tests {
     use crate::Tensor;
     use op_test_util::add;
 
+    #[cfg(feature = "ndarray")]
+    use ndarray::array;
+
     #[test]
     fn test_add_op() {
         let ctx = Context::new(ContextOptions::new()).unwrap();
@@ -534,6 +537,45 @@ mod tests {
         //  [[2, 4],  = [[1, 2],  + [1, 2]
         //   [4, 6]]     [3, 4]]
         let h_z = add(&ctx, &h, &[1, 2]).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 4, 6]).unwrap();
+        assert_eq!(z, expected);
+    }
+
+    #[cfg(feature = "ndarray")]
+    #[test]
+    fn test_add_tensor_and_ndarray() {
+        let values = [1i32, 2, 3, 4];
+        let ctx = Context::new(ContextOptions::new()).unwrap();
+
+        // h = [[1, 2],
+        //      [3, 4]]
+        let h = Tensor::new(&[2, 2])
+            .with_values(&values)
+            .unwrap()
+            .into_handle(&ctx)
+            .unwrap();
+
+        // tensor and scalar, braodcast
+        //  [[2, 3],  = [[1, 2],  + 1
+        //   [4, 5]]     [3, 4]]
+        let h_z = add(&ctx, &h, &array![1]).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
+        assert_eq!(z, expected);
+
+        // tensor and array, broadcast
+        //  [[2, 3],  = [[1, 2],  + 1
+        //   [4, 5]]     [3, 4]]
+        let h_z = add(&ctx, &h, &array![[1]]).unwrap();
+        let z = h_z.resolve::<i32>().unwrap();
+        let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 3, 4, 5]).unwrap();
+        assert_eq!(z, expected);
+
+        // handle and array (horizontal vector), broadcst
+        //  [[2, 4],  = [[1, 2],  + [1, 2]
+        //   [4, 6]]     [3, 4]]
+        let h_z = add(&ctx, &h, &array![1, 2]).unwrap();
         let z = h_z.resolve::<i32>().unwrap();
         let expected = Tensor::new(&[2, 2]).with_values(&[2i32, 4, 4, 6]).unwrap();
         assert_eq!(z, expected);


### PR DESCRIPTION
In this PR, I have implemented the ToTensorHandle trait for several data types that can be converted to Tensor to make the eager API easier to use.

This is a part of  #321.