### PR TITLE
Add support for static linking

### DIFF
--- a/tensorflow-sys/README.md
+++ b/tensorflow-sys/README.md
@@ -60,6 +60,9 @@ compiled library will be picked up.
 **macOS Note**: Via [Homebrew](https://brew.sh/), you can just run
 `brew install libtensorflow`.
 
+To statically link Tensorflow, set the environment variable
+`TENSORFLOW_LIB_STATIC` to the directory containing `libtensorflow.a`
+
 ## Resources
 
 [bazel]: http://www.bazel.io

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -44,6 +44,11 @@ fn main() {
         return;
     }
 
+    if check_static_link() {
+        log!("Returing early because {} is being statically linked", LIBRARY);
+        return;
+    }
+
     if check_windows_lib() {
         log!("Returning early because {} was already found", LIBRARY);
         return;
@@ -468,4 +473,21 @@ fn check_bazel() -> Result<(), Box<dyn Error>> {
         return Err("Did not find version number in `bazel version` output.".into());
     }
     Ok(())
+}
+
+fn check_static_link() -> bool {
+    if let Ok(path) = env::var("TENSORFLOW_LIB_STATIC") {
+        println!("cargo:rustc-link-search=native={}", path);
+        println!("cargo:rustc-link-lib=static={}", LIBRARY);
+        #[cfg(target_os = "linux")]
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        #[cfg(target_os = "macos")]
+        {
+            println!("cargo:rustc-link-lib=c++");
+            println!("cargo:rustc-link-lib=framework=foundation");
+        }
+        true
+    } else {
+        false
+    }
 }

--- a/tensorflow-sys/build.rs
+++ b/tensorflow-sys/build.rs
@@ -45,7 +45,10 @@ fn main() {
     }
 
     if check_static_link() {
-        log!("Returing early because {} is being statically linked", LIBRARY);
+        log!(
+            "Returing early because {} is being statically linked",
+            LIBRARY
+        );
         return;
     }
 


### PR DESCRIPTION
While tensorflow doesn't officially support building a static library,
it is relatively straightforward on Unix using instructions found by the
community at https://github.com/tensorflow/tensorflow/issues/28388. This
allows tensorflow-sys to use a static library should one already exist.

No attempt is made to add any support for automatically building a
static library. It is entirely on the user to go through the trouble of
producing `libtensorflow.a` should they want to use it. This commit
*only* allows the user to ask the build script to use the static library
they have built.