### PR TITLE
Generate eager and ndarray docs when releasing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 # Prevent downloading or building TensorFlow when building docs on docs.rs.
 [package.metadata.docs.rs]
-features = ["private-docs-rs"]
+features = ["private-docs-rs", "tensorflow_unstable", "ndarray", "eager"]
 
 [dependencies]
 libc = "0.2.98"

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -2,6 +2,13 @@
 //!
 //! WARNING: The underlying C-API for the eager execution is not guaranteed to be
 //! stable and can be changed without notice, which could result in breaking.
+//!
+//! This API requires the `eager` feature to be enabled as follows:
+//!
+//! ```
+//! [dependencies]
+//! tensorflow = { version = "0.18", features = ["eager"] }
+//! ```
 
 mod context;
 pub use context::*;

--- a/test-all
+++ b/test-all
@@ -52,8 +52,8 @@ run cargo test -vv -j 2 --features ndarray
 run cargo run --example regression
 run cargo run --example xor
 run cargo run --features tensorflow_unstable --example expressions
-run cargo doc -vv --features tensorflow_unstable
-run cargo doc -vv --features tensorflow_unstable,private-docs-rs
+run cargo doc -vv --features tensorflow_unstable,ndarray,eager
+run cargo doc -vv --features tensorflow_unstable,ndarray,eager,private-docs-rs
 # TODO(#66): Re-enable: (cd tensorflow-sys && cargo test -vv -j 1)
 (cd tensorflow-sys && run cargo run --example multiplication)
 (cd tensorflow-sys && run cargo run --example tf_version)


### PR DESCRIPTION
Thank you for releasing v.0.18.0 of this crate. Also, the documentation for this crate is back in #336 and users can now check it at docs.rs.

https://docs.rs/tensorflow/0.18.0/tensorflow/index.html

However, I noticed that there is no additional features when generating the documentation. Also, the docs for https://tensorflow.github.io/rust/tensorflow/ are missing the eager and ndarray feature docs.

This PR resolves the above inconsistent docs in both docs.rs and github.io.