### PR TITLE
update mobilenetv3 example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ rustversion = "1.0.5"
 [dev-dependencies]
 random = "0.12.2"
 serial_test = "0.5.1"
-image = "0.23.14"
 
 [features]
 tensorflow_gpu = ["tensorflow-sys/tensorflow_gpu"]
@@ -68,3 +67,4 @@ name = "xor"
 
 [[example]]
 name = "mobilenetv3"
+required-features = ["eager"]


### PR DESCRIPTION
Now an input image is loaded using the eager API, so the `image` dev-dependency was removed.