### PR TITLE
Add Operation Instances for accessing graph edges during graph construction

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1037,6 +1037,15 @@ impl Operation {
         }
     }
 
+    /// Returns the given output edge.
+    /// The index argument is the index into the current operation's output array,
+    pub fn output(&self, index: usize) -> Output {
+        crate::Output {
+            operation: self.clone(),
+            index: index as c_int,
+        }
+    }
+
     // TODO: Figure out what this does and document it.
     #[allow(missing_docs)]
     pub fn output_list_length(&self, arg_name: &str) -> Result<usize> {


### PR DESCRIPTION
Expose Output types for each Operation as mentioned in issue #358 and create an object we can add features to such as Input types for runtime (graph build time) access of Operation properties.