### PR TITLE
Add support for saving to and restoring from checkpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustversion = "1.0.9"
 [dev-dependencies]
 rand = "0.8.5"
 serial_test = "0.9.0"
+tempdir = "0.3"
 
 [features]
 default = ["tensorflow-sys"]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,284 @@
+//! This module supports saving and restoring variables using Tensorflow checkpoints in SaveV2 format
+
+use crate::{Operation, ops, Scope, Session, SessionRunArgs, Status, Tensor};
+use crate::option_insert_result::get_or_insert_with_result;
+
+#[derive(Debug)]
+struct SaveRestoreOps {
+    pub prefix_save: Operation,
+    pub prefix_restore: Operation,
+    pub save_op: Operation,
+    pub restore_op: Operation
+}
+
+/// Checkpointing and restoring struct
+#[derive(Debug)]
+pub struct CheckpointMaker {
+    scope: Scope,
+    variables: Box<[String]>,
+    save_restore_ops: Option<SaveRestoreOps>
+}
+
+impl CheckpointMaker {
+    /// Creates a new CheckpointMaker for a Scope, with a list of variables to save/restore.
+    /// The scope is used to modify the graph to add the save and restore ops.
+    ///
+    /// In order to provide a scope for the CheckpointMaker one can use scope.new_sub_scope("")
+    /// as Scope does not support the Clone trait at present
+    fn new(scope: Scope, variables: Box<[String]>) -> CheckpointMaker {
+        CheckpointMaker { scope, variables, save_restore_ops: None }
+    }
+
+    /// Add save and restore ops to the graph
+    fn build_save_ops(&mut self) -> Result<SaveRestoreOps, Status> {
+        let mut all_variable_ops_opt: Option<Vec<Operation>>  = None;
+        fn make_all_variable_ops(myself: &mut CheckpointMaker) -> Result<Vec<Operation>, Status>
+            {
+                let graph = myself.scope.graph();
+                Ok(myself.variables
+                    .iter()
+                    .map(|v: &String| -> Result<Operation, Status>
+                        { Ok(graph.operation_by_name_required(v.as_str())?.clone()) })
+                    .collect::<Result<Vec<_>, Status>>()?)
+            }
+
+        let existing_save_op = self.scope.graph().operation_by_name("save")?;
+        let (prefix_save, save_op) = if let Some(op) = existing_save_op {
+            let prefix_save_op = self.scope.graph().operation_by_name_required("prefix_save")?;
+            (prefix_save_op, op)
+        } else {
+            let all_variable_ops =
+                get_or_insert_with_result(&mut all_variable_ops_opt, || make_all_variable_ops(self))?;
+            let prefix_save = ops::Placeholder::new()
+                .dtype(crate::DataType::String)
+                .build(&mut self.scope.with_op_name("prefix_save"))?;
+            let tensor_names = ops::constant(
+                &self.variables
+                    .iter()
+                    .map(|v| (*v).to_string())
+                    .collect::<Vec<_>>()[..],
+                &mut self.scope,
+            )?;
+            let shape_and_slices = ops::constant(
+                &self.variables.iter().map(|_| "".to_string()).collect::<Vec<_>>()[..],
+                &mut self.scope,
+            )?;
+            let tensors = all_variable_ops.iter().map(|v|  v.output(0).clone()).collect::<Vec<_>>();
+
+            let mut g = self.scope.graph_mut();
+            let mut nd = g.new_operation("SaveV2", "save")?;
+            nd.add_input(prefix_save.clone());
+            nd.add_input(tensor_names);
+            nd.add_input(shape_and_slices);
+            nd.add_input_list(&tensors[..]);
+
+            let dtypes = all_variable_ops.iter().map(|v| v.get_attr_type("dtype"))
+                .collect::<Result<Vec<_>, Status>>()?;
+            nd.set_attr_type_list(
+                "dtypes",
+                &dtypes[..],
+            )?;
+            let save_op = nd.finish()?;
+            (prefix_save, save_op)
+        };
+        let opt_restore_op = self.scope.graph().operation_by_name("restore")?;
+        let (prefix_restore, restore_op) = if let Some(op) = opt_restore_op {
+            let the_prefix_restore = self.scope.graph().operation_by_name_required("prefix_restore")?;
+            (the_prefix_restore, op)
+        } else {
+            let all_variable_ops = get_or_insert_with_result(&mut all_variable_ops_opt, || make_all_variable_ops(self))?;
+            let prefix_restore = crate::ops::Placeholder::new()
+                .dtype(crate::DataType::String)
+                .build(&mut self.scope.with_op_name("prefix_restore"))?;
+            let restore_op = {
+                let all_var_names = self.variables
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>();
+                let tensor_names = ops::constant(&all_var_names[..], &mut self.scope)?;
+                let shape_and_slices = ops::constant(
+                    &self.variables.iter().map(|_| "".to_string()).collect::<Vec<_>>()[..],
+                    &mut self.scope,
+                )?;
+                let mut g = self.scope.graph_mut();
+                let mut nd = g.new_operation("RestoreV2", "restore")?;
+                nd.add_input(prefix_restore.clone());
+                nd.add_input(tensor_names);
+                nd.add_input(shape_and_slices);
+                let dtypes = all_variable_ops.iter().map(|v| v.get_attr_type("dtype"))
+                    .collect::<Result<Vec<_>, Status>>()?;
+                nd.set_attr_type_list(
+                    "dtypes",
+                    &dtypes[..],
+                )?;
+                nd.finish()?
+            };
+            {
+                let mut restore_var_ops = Vec::<Operation>::new();
+                for (i, var) in self.variables.iter().enumerate() {
+                    let var_op = self.scope.graph().operation_by_name_required(var.as_str())?;
+                    restore_var_ops.push(
+                        ops::assign(var_op, crate::Output {
+                            operation: restore_op.clone(),
+                            index: i as i32,
+                        }, &mut self.scope.new_sub_scope(format!("restore{}", i).as_str()))?);
+                }
+                let mut no_op = crate::ops::NoOp::new();
+                for op in restore_var_ops {
+                    no_op = no_op.add_control_input(op);
+                }
+                (prefix_restore, no_op.build(&mut self.scope)?)
+            }
+        };
+        Ok(SaveRestoreOps{prefix_save, prefix_restore, save_op, restore_op})
+    }
+
+    fn get_save_operation(&mut self) -> Result<&SaveRestoreOps, Status> {
+        if self.save_restore_ops.is_none() {
+            self.save_restore_ops = Some(self.build_save_ops()?);
+        }
+        let save_r_op_ref = self.save_restore_ops.as_ref();
+        // SAFETY: the condition above has ensured that self.save_restore_ops is Some(_)
+        let save_r_op = unsafe {save_r_op_ref.unwrap_unchecked()};
+        Ok(save_r_op)
+    }
+
+    /// Save the variables listed in this CheckpointMaker to the checkpoint with base filename backup_filename_base
+    pub fn save(&mut self, session: &Session, backup_filename_base: &str) -> Result<(), Status> {
+        let save_restore_ops =
+            self.get_save_operation()?;
+        let prefix_arg = Tensor::from(backup_filename_base.to_string());
+        let mut run_args = SessionRunArgs::new();
+        run_args.add_feed(&save_restore_ops.prefix_save, 0, &prefix_arg);
+        run_args.add_target(&save_restore_ops.save_op);
+        session.run(&mut run_args)?;
+        Ok(())
+    }
+
+    /// Restore into the session the variables listed in this CheckpointMaker from the checkpoint
+    /// in path_base
+    pub fn restore(&mut self, session: &Session, path_base: &str) -> Result<(), Status> {
+        let save_restore_ops =
+            self.get_save_operation()?;
+        let prefix_arg = Tensor::from(path_base.to_string());
+        let mut run_args = SessionRunArgs::new();
+        run_args.add_feed(&save_restore_ops.prefix_restore, 0, &prefix_arg);
+        run_args.add_target(&save_restore_ops.restore_op);
+        session.run(&mut run_args)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CheckpointMaker, Scope, Session, SessionOptions, Variable, DataType, ops, Tensor, Status, Operation, SessionRunArgs, Code, FetchToken};
+    use crate::ops::Placeholder;
+
+    fn make_variable(scope: &mut Scope, name: &str, dims: &[u64], values: &[f32]) -> Result<Variable, Status> {
+        Ok(Variable::builder()
+               .const_initial_value(Tensor::new(dims).with_values(values)?)
+            .data_type(DataType::Float)
+            .build(&mut scope.with_op_name(name))?)
+    }
+
+    fn create_assignment(var: &Variable, scope: &mut Scope) -> Result<(Operation, Operation), Status> {
+        let placeholder = Placeholder::new().dtype(DataType::Float)
+            .shape(var.shape.clone()).build(&mut scope.with_op_name(var.name.as_str()))?;
+        Ok((placeholder.clone(), ops::assign(var.output.clone(), placeholder, scope)?))
+    }
+
+    struct MyScopeData {
+        pub scope: Scope,
+        pub variables: [Variable; 3],
+    }
+
+    // Initialize a scope and place same variables in it
+    fn create_scope() -> Result<MyScopeData, Status> {
+        let mut scope = Scope::new_root_scope();
+        let var_w = make_variable(&mut scope, "w", &[], &[2.2])?;
+        let var_b = make_variable(&mut scope, "b", &[3], &[1.0, 2.0, 4.5])?;
+        let var_a = make_variable(&mut scope, "a", &[3, 2], &[1.0, 2.0, 3.3, 7.0, 8.0, 8.5])?;
+        Ok(MyScopeData{scope, variables: [var_w, var_b, var_a]})
+    }
+
+    struct AssignData {
+        pub placeholder_ops: Box<[Operation]>,
+        pub assign_op: Operation
+    }
+    fn add_assign_op(scope_data: &mut MyScopeData) -> Result<AssignData, Status> {
+        let mut placeholder_scope = scope_data.scope.new_sub_scope("placeholder");
+        let mut placeholders: Vec<Operation> = Vec::new();
+        let mut no_op_bld = ops::NoOp::new();
+        for var in scope_data.variables.as_ref() {
+            let (placeholder, assign_op) = create_assignment(&var, &mut placeholder_scope)?;
+            placeholders.push(placeholder);
+            no_op_bld = no_op_bld.add_control_input(assign_op);
+        }
+        let assign_op = no_op_bld.build(&mut scope_data.scope)?;
+        Ok(AssignData {placeholder_ops: placeholders.into_boxed_slice(), assign_op})
+    }
+
+    fn assign_variables(session: &Session, scope_data: &MyScopeData, assign_data: &AssignData, values: &[&[f32]] ) -> Result<(), Status> {
+        let mut values_fed: Vec<Tensor<f32>> = Vec::new();
+        let mut session_run = SessionRunArgs::new();
+        for i_var in 0..assign_data.placeholder_ops.len() {
+            let value_fed_as_tensor = Tensor::new(
+                &scope_data.variables[i_var].shape().0.as_ref()
+                    .ok_or(Status::new_set(Code::Internal, "Shape not present")?)?
+                    .iter()
+                    .map(|o| o.map(|i| i as u64).ok_or(Status::new_set(Code::Internal, "Shape item not present")?))
+                    .collect::<Result<Vec<u64>, Status>>()?
+                    .as_ref()
+            ).with_values(&values[i_var])?;
+            values_fed.push(value_fed_as_tensor);
+        }
+        for i_var in 0..assign_data.placeholder_ops.len() {
+            session_run.add_feed(&assign_data.placeholder_ops[i_var], 0,
+                                 &values_fed[i_var]);
+        }
+        session_run.add_target(&assign_data.assign_op);
+        session.run(&mut session_run)?;
+        Ok(())
+    }
+
+    fn check_variables(session: &Session, variables: &[Variable], values: &[&[f32]]) -> Result<(), Status> {
+        let mut session_run = SessionRunArgs::new();
+        let mut tokens: Vec<FetchToken> = Vec::with_capacity(variables.len());
+        for i in 0..variables.len() {
+            tokens.push(session_run.request_fetch(&variables[i].output().operation, variables[i].output().index));
+        }
+        session.run(&mut session_run)?;
+        for i in 0..variables.len() {
+            let got_tensor: Tensor<f32> = session_run.fetch(tokens[i])?;
+            assert_eq!(values[i], got_tensor.as_ref());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn simple_save() -> Result<(),Box<dyn std::error::Error>>{
+        let mut first_scope_data = create_scope()?;
+        let assign_data = add_assign_op(&mut first_scope_data)?;
+        let first_session = Session::new(&SessionOptions::new(), &first_scope_data.scope.graph())?;
+        let new_values: [&[f32];3] = [&[5.1],
+            &[4.0, 2.2, 6.0],
+            &[11.0, 12.0, 13.6, 17.1, 18.4, 19.5]];
+        assign_variables(&first_session, &first_scope_data, &assign_data, &new_values)?;
+        let variable_names = first_scope_data.variables.as_ref().iter()
+            .map(|v| String::from(v.name()))
+            .collect::<Vec<_>>().into_boxed_slice();
+        let mut checkpoint = CheckpointMaker::new(first_scope_data.scope.new_sub_scope(""),
+                                                  variable_names.clone());
+        let temp_dir = tempdir::TempDir::new("test-tensorflow")?;
+        let checkpoint_path = temp_dir.path().join("checkpoint-vars");
+        let checkpoint_path_str = checkpoint_path.into_os_string().into_string().map_err(|_| "Cannot convert checkpoint path")?;
+        checkpoint.save(&first_session, checkpoint_path_str.as_str())?;
+        let MyScopeData {scope: second_scope, variables: second_variables} = create_scope()?;
+        let second_session = Session::new(&SessionOptions::new(), &second_scope.graph())?;
+        let mut second_checkpoint = CheckpointMaker::new(second_scope,
+                                                         variable_names);
+        second_checkpoint.restore(&second_session, checkpoint_path_str.as_str())?;
+        check_variables(&second_session, &second_variables, &new_values)?;
+        Ok(())
+    }
+}

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,14 +1,14 @@
 //! This module supports saving and restoring variables using Tensorflow checkpoints in SaveV2 format
 
-use crate::{Operation, ops, Scope, Session, SessionRunArgs, Status, Tensor};
 use crate::option_insert_result::OptionInsertWithResult;
+use crate::{ops, Operation, Scope, Session, SessionRunArgs, Status, Tensor};
 
 #[derive(Debug)]
 struct SaveRestoreOps {
     pub prefix_save: Operation,
     pub prefix_restore: Operation,
     pub save_op: Operation,
-    pub restore_op: Operation
+    pub restore_op: Operation,
 }
 
 /// Checkpointing and restoring struct
@@ -16,7 +16,7 @@ struct SaveRestoreOps {
 pub struct CheckpointMaker {
     scope: Scope,
     variables: Box<[String]>,
-    save_restore_ops: Option<SaveRestoreOps>
+    save_restore_ops: Option<SaveRestoreOps>,
 }
 
 impl CheckpointMaker {
@@ -26,25 +26,33 @@ impl CheckpointMaker {
     /// In order to provide a scope for the CheckpointMaker one can use scope.new_sub_scope("")
     /// as Scope does not support the Clone trait at present
     pub fn new(scope: Scope, variables: Box<[String]>) -> CheckpointMaker {
-        CheckpointMaker { scope, variables, save_restore_ops: None }
+        CheckpointMaker {
+            scope,
+            variables,
+            save_restore_ops: None,
+        }
     }
 
     /// Add save and restore ops to the graph
     fn build_save_ops(&mut self) -> Result<SaveRestoreOps, Status> {
-        let mut all_variable_ops_opt: Option<Vec<Operation>>  = None;
-        fn make_all_variable_ops(myself: &mut CheckpointMaker) -> Result<Vec<Operation>, Status>
-            {
-                let graph = myself.scope.graph();
-                Ok(myself.variables
-                    .iter()
-                    .map(|v: &String| -> Result<Operation, Status>
-                        { Ok(graph.operation_by_name_required(v.as_str())?.clone()) })
-                    .collect::<Result<Vec<_>, Status>>()?)
-            }
+        let mut all_variable_ops_opt: Option<Vec<Operation>> = None;
+        fn make_all_variable_ops(myself: &mut CheckpointMaker) -> Result<Vec<Operation>, Status> {
+            let graph = myself.scope.graph();
+            Ok(myself
+                .variables
+                .iter()
+                .map(|v: &String| -> Result<Operation, Status> {
+                    Ok(graph.operation_by_name_required(v.as_str())?.clone())
+                })
+                .collect::<Result<Vec<_>, Status>>()?)
+        }
 
         let existing_save_op = self.scope.graph().operation_by_name("save")?;
         let (prefix_save, save_op) = if let Some(op) = existing_save_op {
-            let prefix_save_op = self.scope.graph().operation_by_name_required("prefix_save")?;
+            let prefix_save_op = self
+                .scope
+                .graph()
+                .operation_by_name_required("prefix_save")?;
             (prefix_save_op, op)
         } else {
             let all_variable_ops =
@@ -53,17 +61,25 @@ impl CheckpointMaker {
                 .dtype(crate::DataType::String)
                 .build(&mut self.scope.with_op_name("prefix_save"))?;
             let tensor_names = ops::constant(
-                &self.variables
+                &self
+                    .variables
                     .iter()
                     .map(|v| (*v).to_string())
                     .collect::<Vec<_>>()[..],
                 &mut self.scope,
             )?;
             let shape_and_slices = ops::constant(
-                &self.variables.iter().map(|_| "".to_string()).collect::<Vec<_>>()[..],
+                &self
+                    .variables
+                    .iter()
+                    .map(|_| "".to_string())
+                    .collect::<Vec<_>>()[..],
                 &mut self.scope,
             )?;
-            let tensors = all_variable_ops.iter().map(|v|  v.output(0).clone()).collect::<Vec<_>>();
+            let tensors = all_variable_ops
+                .iter()
+                .map(|v| v.output(0).clone())
+                .collect::<Vec<_>>();
 
             let mut g = self.scope.graph_mut();
             let mut nd = g.new_operation("SaveV2", "save")?;
@@ -72,32 +88,40 @@ impl CheckpointMaker {
             nd.add_input(shape_and_slices);
             nd.add_input_list(&tensors[..]);
 
-            let dtypes = all_variable_ops.iter().map(|v| v.get_attr_type("dtype"))
+            let dtypes = all_variable_ops
+                .iter()
+                .map(|v| v.get_attr_type("dtype"))
                 .collect::<Result<Vec<_>, Status>>()?;
-            nd.set_attr_type_list(
-                "dtypes",
-                &dtypes[..],
-            )?;
+            nd.set_attr_type_list("dtypes", &dtypes[..])?;
             let save_op = nd.finish()?;
             (prefix_save, save_op)
         };
         let opt_restore_op = self.scope.graph().operation_by_name("restore")?;
         let (prefix_restore, restore_op) = if let Some(op) = opt_restore_op {
-            let the_prefix_restore = self.scope.graph().operation_by_name_required("prefix_restore")?;
+            let the_prefix_restore = self
+                .scope
+                .graph()
+                .operation_by_name_required("prefix_restore")?;
             (the_prefix_restore, op)
         } else {
-            let all_variable_ops = all_variable_ops_opt.get_or_insert_with_result(|| make_all_variable_ops(self))?;
+            let all_variable_ops =
+                all_variable_ops_opt.get_or_insert_with_result(|| make_all_variable_ops(self))?;
             let prefix_restore = ops::Placeholder::new()
                 .dtype(crate::DataType::String)
                 .build(&mut self.scope.with_op_name("prefix_restore"))?;
             let restore_op = {
-                let all_var_names = self.variables
+                let all_var_names = self
+                    .variables
                     .iter()
                     .map(|v| v.to_string())
                     .collect::<Vec<_>>();
                 let tensor_names = ops::constant(&all_var_names[..], &mut self.scope)?;
                 let shape_and_slices = ops::constant(
-                    &self.variables.iter().map(|_| "".to_string()).collect::<Vec<_>>()[..],
+                    &self
+                        .variables
+                        .iter()
+                        .map(|_| "".to_string())
+                        .collect::<Vec<_>>()[..],
                     &mut self.scope,
                 )?;
                 let mut g = self.scope.graph_mut();
@@ -105,23 +129,28 @@ impl CheckpointMaker {
                 nd.add_input(prefix_restore.clone());
                 nd.add_input(tensor_names);
                 nd.add_input(shape_and_slices);
-                let dtypes = all_variable_ops.iter().map(|v| v.get_attr_type("dtype"))
+                let dtypes = all_variable_ops
+                    .iter()
+                    .map(|v| v.get_attr_type("dtype"))
                     .collect::<Result<Vec<_>, Status>>()?;
-                nd.set_attr_type_list(
-                    "dtypes",
-                    &dtypes[..],
-                )?;
+                nd.set_attr_type_list("dtypes", &dtypes[..])?;
                 nd.finish()?
             };
             {
                 let mut restore_var_ops = Vec::<Operation>::new();
                 for (i, var) in self.variables.iter().enumerate() {
-                    let var_op = self.scope.graph().operation_by_name_required(var.as_str())?;
-                    restore_var_ops.push(
-                        ops::assign(var_op, crate::Output {
+                    let var_op = self
+                        .scope
+                        .graph()
+                        .operation_by_name_required(var.as_str())?;
+                    restore_var_ops.push(ops::assign(
+                        var_op,
+                        crate::Output {
                             operation: restore_op.clone(),
                             index: i as i32,
-                        }, &mut self.scope.new_sub_scope(format!("restore{}", i).as_str()))?);
+                        },
+                        &mut self.scope.new_sub_scope(format!("restore{}", i).as_str()),
+                    )?);
                 }
                 let mut no_op = ops::NoOp::new();
                 for op in restore_var_ops {
@@ -130,7 +159,12 @@ impl CheckpointMaker {
                 (prefix_restore, no_op.build(&mut self.scope)?)
             }
         };
-        Ok(SaveRestoreOps{prefix_save, prefix_restore, save_op, restore_op})
+        Ok(SaveRestoreOps {
+            prefix_save,
+            prefix_restore,
+            save_op,
+            restore_op,
+        })
     }
 
     fn get_save_operation(&mut self) -> Result<&SaveRestoreOps, Status> {
@@ -139,14 +173,13 @@ impl CheckpointMaker {
         }
         let save_r_op_ref = self.save_restore_ops.as_ref();
         // SAFETY: the condition above has ensured that self.save_restore_ops is Some(_)
-        let save_r_op = unsafe {save_r_op_ref.unwrap_unchecked()};
+        let save_r_op = unsafe { save_r_op_ref.unwrap_unchecked() };
         Ok(save_r_op)
     }
 
     /// Save the variables listed in this CheckpointMaker to the checkpoint with base filename backup_filename_base
     pub fn save(&mut self, session: &Session, backup_filename_base: &str) -> Result<(), Status> {
-        let save_restore_ops =
-            self.get_save_operation()?;
+        let save_restore_ops = self.get_save_operation()?;
         let prefix_arg = Tensor::from(backup_filename_base.to_string());
         let mut run_args = SessionRunArgs::new();
         run_args.add_feed(&save_restore_ops.prefix_save, 0, &prefix_arg);
@@ -158,8 +191,7 @@ impl CheckpointMaker {
     /// Restore into the session the variables listed in this CheckpointMaker from the checkpoint
     /// in path_base
     pub fn restore(&mut self, session: &Session, path_base: &str) -> Result<(), Status> {
-        let save_restore_ops =
-            self.get_save_operation()?;
+        let save_restore_ops = self.get_save_operation()?;
         let prefix_arg = Tensor::from(path_base.to_string());
         let mut run_args = SessionRunArgs::new();
         run_args.add_feed(&save_restore_ops.prefix_restore, 0, &prefix_arg);
@@ -171,20 +203,36 @@ impl CheckpointMaker {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CheckpointMaker, Scope, Session, SessionOptions, Variable, DataType, ops, Tensor, Status, Operation, SessionRunArgs, Code, FetchToken};
     use crate::ops::Placeholder;
+    use crate::{
+        ops, CheckpointMaker, Code, DataType, FetchToken, Operation, Scope, Session,
+        SessionOptions, SessionRunArgs, Status, Tensor, Variable,
+    };
 
-    fn make_variable(scope: &mut Scope, name: &str, dims: &[u64], values: &[f32]) -> Result<Variable, Status> {
+    fn make_variable(
+        scope: &mut Scope,
+        name: &str,
+        dims: &[u64],
+        values: &[f32],
+    ) -> Result<Variable, Status> {
         Ok(Variable::builder()
-               .const_initial_value(Tensor::new(dims).with_values(values)?)
+            .const_initial_value(Tensor::new(dims).with_values(values)?)
             .data_type(DataType::Float)
             .build(&mut scope.with_op_name(name))?)
     }
 
-    fn create_assignment(var: &Variable, scope: &mut Scope) -> Result<(Operation, Operation), Status> {
-        let placeholder = Placeholder::new().dtype(DataType::Float)
-            .shape(var.shape.clone()).build(&mut scope.with_op_name(var.name.as_str()))?;
-        Ok((placeholder.clone(), ops::assign(var.output.clone(), placeholder, scope)?))
+    fn create_assignment(
+        var: &Variable,
+        scope: &mut Scope,
+    ) -> Result<(Operation, Operation), Status> {
+        let placeholder = Placeholder::new()
+            .dtype(DataType::Float)
+            .shape(var.shape.clone())
+            .build(&mut scope.with_op_name(var.name.as_str()))?;
+        Ok((
+            placeholder.clone(),
+            ops::assign(var.output.clone(), placeholder, scope)?,
+        ))
     }
 
     struct MyScopeData {
@@ -198,12 +246,15 @@ mod tests {
         let var_w = make_variable(&mut scope, "w", &[], &[2.2])?;
         let var_b = make_variable(&mut scope, "b", &[3], &[1.0, 2.0, 4.5])?;
         let var_a = make_variable(&mut scope, "a", &[3, 2], &[1.0, 2.0, 3.3, 7.0, 8.0, 8.5])?;
-        Ok(MyScopeData{scope, variables: [var_w, var_b, var_a]})
+        Ok(MyScopeData {
+            scope,
+            variables: [var_w, var_b, var_a],
+        })
     }
 
     struct AssignData {
         pub placeholder_ops: Box<[Operation]>,
-        pub assign_op: Operation
+        pub assign_op: Operation,
     }
     fn add_assign_op(scope_data: &mut MyScopeData) -> Result<AssignData, Status> {
         let mut placeholder_scope = scope_data.scope.new_sub_scope("placeholder");
@@ -215,37 +266,59 @@ mod tests {
             no_op_bld = no_op_bld.add_control_input(assign_op);
         }
         let assign_op = no_op_bld.build(&mut scope_data.scope)?;
-        Ok(AssignData {placeholder_ops: placeholders.into_boxed_slice(), assign_op})
+        Ok(AssignData {
+            placeholder_ops: placeholders.into_boxed_slice(),
+            assign_op,
+        })
     }
 
-    fn assign_variables(session: &Session, scope_data: &MyScopeData, assign_data: &AssignData, values: &[&[f32]] ) -> Result<(), Status> {
-        let mut values_fed: Vec<Tensor<f32>> = Vec::with_capacity(assign_data.placeholder_ops.len());
+    fn assign_variables(
+        session: &Session,
+        scope_data: &MyScopeData,
+        assign_data: &AssignData,
+        values: &[&[f32]],
+    ) -> Result<(), Status> {
+        let mut values_fed: Vec<Tensor<f32>> =
+            Vec::with_capacity(assign_data.placeholder_ops.len());
         let mut session_run = SessionRunArgs::new();
         for i_var in 0..assign_data.placeholder_ops.len() {
             let value_fed_as_tensor = Tensor::new(
-                &scope_data.variables[i_var].shape().0.as_ref()
+                &scope_data.variables[i_var]
+                    .shape()
+                    .0
+                    .as_ref()
                     .ok_or(Status::new_set(Code::Internal, "Shape not present")?)?
                     .iter()
-                    .map(|o| o.map(|i| i as u64).ok_or(Status::new_set(Code::Internal, "Shape item not present")?))
+                    .map(|o| {
+                        o.map(|i| i as u64)
+                            .ok_or(Status::new_set(Code::Internal, "Shape item not present")?)
+                    })
                     .collect::<Result<Vec<u64>, Status>>()?
-                    .as_ref()
-            ).with_values(&values[i_var])?;
+                    .as_ref(),
+            )
+            .with_values(&values[i_var])?;
             values_fed.push(value_fed_as_tensor);
         }
         for i_var in 0..assign_data.placeholder_ops.len() {
-            session_run.add_feed(&assign_data.placeholder_ops[i_var], 0,
-                                 &values_fed[i_var]);
+            session_run.add_feed(&assign_data.placeholder_ops[i_var], 0, &values_fed[i_var]);
         }
         session_run.add_target(&assign_data.assign_op);
         session.run(&mut session_run)?;
         Ok(())
     }
 
-    fn check_variables(session: &Session, variables: &[Variable], values: &[&[f32]]) -> Result<(), Status> {
+    fn check_variables(
+        session: &Session,
+        variables: &[Variable],
+        values: &[&[f32]],
+    ) -> Result<(), Status> {
         let mut session_run = SessionRunArgs::new();
         let mut tokens: Vec<FetchToken> = Vec::with_capacity(variables.len());
         for i in 0..variables.len() {
-            tokens.push(session_run.request_fetch(&variables[i].output().operation, variables[i].output().index));
+            tokens.push(session_run.request_fetch(
+                &variables[i].output().operation,
+                variables[i].output().index,
+            ));
         }
         session.run(&mut session_run)?;
         for i in 0..variables.len() {
@@ -256,27 +329,40 @@ mod tests {
     }
 
     #[test]
-    fn simple_save() -> Result<(),Box<dyn std::error::Error>>{
+    fn simple_save() -> Result<(), Box<dyn std::error::Error>> {
         let mut first_scope_data = create_scope()?;
         let assign_data = add_assign_op(&mut first_scope_data)?;
         let first_session = Session::new(&SessionOptions::new(), &first_scope_data.scope.graph())?;
-        let new_values: [&[f32];3] = [&[5.1],
+        let new_values: [&[f32]; 3] = [
+            &[5.1],
             &[4.0, 2.2, 6.0],
-            &[11.0, 12.0, 13.6, 17.1, 18.4, 19.5]];
+            &[11.0, 12.0, 13.6, 17.1, 18.4, 19.5],
+        ];
         assign_variables(&first_session, &first_scope_data, &assign_data, &new_values)?;
-        let variable_names = first_scope_data.variables.as_ref().iter()
+        let variable_names = first_scope_data
+            .variables
+            .as_ref()
+            .iter()
             .map(|v| String::from(v.name()))
-            .collect::<Vec<_>>().into_boxed_slice();
-        let mut checkpoint = CheckpointMaker::new(first_scope_data.scope.new_sub_scope(""),
-                                                  variable_names.clone());
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let mut checkpoint = CheckpointMaker::new(
+            first_scope_data.scope.new_sub_scope(""),
+            variable_names.clone(),
+        );
         let temp_dir = tempdir::TempDir::new("test-tensorflow")?;
         let checkpoint_path = temp_dir.path().join("checkpoint-vars");
-        let checkpoint_path_str = checkpoint_path.into_os_string().into_string().map_err(|_| "Cannot convert checkpoint path")?;
+        let checkpoint_path_str = checkpoint_path
+            .into_os_string()
+            .into_string()
+            .map_err(|_| "Cannot convert checkpoint path")?;
         checkpoint.save(&first_session, checkpoint_path_str.as_str())?;
-        let MyScopeData {scope: second_scope, variables: second_variables} = create_scope()?;
+        let MyScopeData {
+            scope: second_scope,
+            variables: second_variables,
+        } = create_scope()?;
         let second_session = Session::new(&SessionOptions::new(), &second_scope.graph())?;
-        let mut second_checkpoint = CheckpointMaker::new(second_scope,
-                                                         variable_names);
+        let mut second_checkpoint = CheckpointMaker::new(second_scope, variable_names);
         second_checkpoint.restore(&second_session, checkpoint_path_str.as_str())?;
         check_variables(&second_session, &second_variables, &new_values)?;
         Ok(())

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -29,7 +29,7 @@ struct SaveRestoreOps {
 /// checkpoint_maker.save(&session, "data/checkpoint")?;
 /// // then we restore in a different session to continue there
 /// let new_session = Session::new(&SessionOptions::new(), &scope.graph())?;
-/// checkpoint_maker.save(&new_session, "data/checkpoint")?;
+/// checkpoint_maker.restore(&new_session, "data/checkpoint")?;
 /// ```
 ///
 #[derive(Debug)]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -25,7 +25,7 @@ impl CheckpointMaker {
     ///
     /// In order to provide a scope for the CheckpointMaker one can use scope.new_sub_scope("")
     /// as Scope does not support the Clone trait at present
-    fn new(scope: Scope, variables: Box<[String]>) -> CheckpointMaker {
+    pub fn new(scope: Scope, variables: Box<[String]>) -> CheckpointMaker {
         CheckpointMaker { scope, variables, save_restore_ops: None }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,11 @@ pub mod train;
 mod saved_model;
 pub use saved_model::*;
 
+mod checkpoint;
+pub use checkpoint::*;
+
+mod option_insert_result;
+
 #[cfg(feature = "eager")]
 pub mod eager;
 

--- a/src/option_insert_result.rs
+++ b/src/option_insert_result.rs
@@ -1,12 +1,14 @@
 // Similar to Option<T>.get_or_insert_with, for a function that returns a result.
 pub trait OptionInsertWithResult<T> {
     fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
-        where F: FnOnce() -> Result<T, E>;
+    where
+        F: FnOnce() -> Result<T, E>;
 }
 
 impl<T> OptionInsertWithResult<T> for Option<T> {
     fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
-        where F: FnOnce() -> Result<T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
     {
         if self.is_none() {
             *self = Some(f()?);

--- a/src/option_insert_result.rs
+++ b/src/option_insert_result.rs
@@ -1,9 +1,16 @@
 // Similar to Option<T>.get_or_insert_with, for a function that returns a result.
-pub fn get_or_insert_with_result<T, F, E>(opt: &mut Option<T>, f: F) -> Result<&T, E>
-    where F: FnOnce() -> Result<T, E>
-{
-    if opt.is_none() {
-        *opt = Some(f()?);
+pub trait OptionInsertWithResult<T> {
+    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
+        where F: FnOnce() -> Result<T, E>;
+}
+
+impl<T> OptionInsertWithResult<T> for Option<T> {
+    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
+        where F: FnOnce() -> Result<T, E>
+    {
+        if self.is_none() {
+            *self = Some(f()?);
+        }
+        Ok(self.as_ref().unwrap())
     }
-    Ok(opt.as_ref().unwrap())
 }

--- a/src/option_insert_result.rs
+++ b/src/option_insert_result.rs
@@ -1,0 +1,9 @@
+// Similar to Option<T>.get_or_insert_with, for a function that returns a result.
+pub fn get_or_insert_with_result<T, F, E>(opt: &mut Option<T>, f: F) -> Result<&T, E>
+    where F: FnOnce() -> Result<T, E>
+{
+    if opt.is_none() {
+        *opt = Some(f()?);
+    }
+    Ok(opt.as_ref().unwrap())
+}

--- a/src/option_insert_result.rs
+++ b/src/option_insert_result.rs
@@ -1,18 +1,18 @@
 // Similar to Option<T>.get_or_insert_with, for a function that returns a result.
 pub trait OptionInsertWithResult<T> {
-    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
+    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&mut T, E>
     where
         F: FnOnce() -> Result<T, E>;
 }
 
 impl<T> OptionInsertWithResult<T> for Option<T> {
-    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&T, E>
+    fn get_or_insert_with_result<F, E>(&mut self, f: F) -> Result<&mut T, E>
     where
         F: FnOnce() -> Result<T, E>,
     {
         if self.is_none() {
             *self = Some(f()?);
         }
-        Ok(self.as_ref().unwrap())
+        Ok(self.as_mut().unwrap())
     }
 }


### PR DESCRIPTION
This pull request contributes support for saving and restoring of variables using tensorflow `SaveV2`/`RestoreV2` ops, and therefore it is compatible with checkpoints created with `tf.keras.Model.save_weights`.

It includes a test case.